### PR TITLE
Fix doctype serialization

### DIFF
--- a/lib/tree_construction_stage/tree_serializer.js
+++ b/lib/tree_construction_stage/tree_serializer.js
@@ -153,13 +153,16 @@ TreeSerializer.prototype._serializeDocumentTypeNode = function (node) {
 
     this.html += '<!DOCTYPE ' + name;
 
-    if (publicId !== null)
-        this.html += ' PUBLIC "' + publicId + '"';
-    else if (systemId !== null)
+    if (publicId !== null) {
+        var escapedPublicId = publicId.indexOf('"') !== -1 ? '\'' + publicId + '\'' : '"' + publicId + '"';
+        this.html += ' PUBLIC ' + escapedPublicId;
+    } else if (systemId !== null)
         this.html += ' SYSTEM';
 
-    if (systemId !== null)
-        this.html += ' "' + systemId + '"';
+    if (systemId !== null) {
+        var escapedSystemId = systemId.indexOf('"') !== -1 ? '\'' + systemId + '\'' : '"' + systemId + '"';
+        this.html += ' ' + escapedSystemId;
+    }
 
     this.html += '>';
 };


### PR DESCRIPTION
As per tmpvar/jsdom#848 I'll PR this here.

While switching the custom serializer in jsdom I came across some bugs in doctype serialization, this should fix them.

I just noticed I haven't added a test, will add when I get some time and figure out the test system before the merge.
