### PR TITLE
Enhanced location info

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Creates new reusable instance of the `Parser`. Optional `treeAdapter` argument s
 #####  options.decodeHtmlEntities
 Decode HTML-entities like `&amp;`, `&nbsp;`, etc.  Default: `true`. **Warning:** disabling this option may cause output which is not conform HTML5 specification.
 #####  options.locationInfo
-Enables source code location information for the nodes. Default: `false`. When enabled, each node (except root node) has `__location` property, which contains `start` and `end` indices of the node in the source code. If element was implicitly created by the parser it's `__location` property will be `null`. In case the node is not an empty element, `__startTagLocation` and `__endTagLocation` properties contain location information for individual tags in a fashion similar to `__location` property.
+Enables source code location information for the nodes. Default: `false`. When enabled, each node (except root node) has `__location` property, which contains `start` and `end` indices of the node in the source code. If element was implicitly created by the parser it's `__location` property will be `null`. In case the node is not an empty element, `__location` has two addition properties `startTag` and `endTag` which contain location information for individual tags in a fashion similar to `__location` property.
 
 *Example:*
 ```js

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Creates new reusable instance of the `Parser`. Optional `treeAdapter` argument s
 #####  options.decodeHtmlEntities
 Decode HTML-entities like `&amp;`, `&nbsp;`, etc.  Default: `true`. **Warning:** disabling this option may cause output which is not conform HTML5 specification.
 #####  options.locationInfo
-Enables source code location information for the nodes. Default: `false`. When enabled, each node (except root node) has `__location` property, which contains `start` and `end` indices of the node in the source code. If element was implicitly created by the parser it's `__location` property will be `null`.
+Enables source code location information for the nodes. Default: `false`. When enabled, each node (except root node) has `__location` property, which contains `start` and `end` indices of the node in the source code. If element was implicitly created by the parser it's `__location` property will be `null`. In case the node is not an empty element, `__startTagLocation` and `__endTagLocation` properties contain location information for individual tags in a fashion similar to `__location` property.
 
 *Example:*
 ```js

--- a/lib/tree_construction/location_info_mixin.js
+++ b/lib/tree_construction/location_info_mixin.js
@@ -10,13 +10,15 @@ var $ = HTML.TAG_NAMES;
 
 
 function setEndLocation(element, endTagToken) {
-    if(!element.__startTagLocation && element.__location) {
+    if (!element.__startTagLocation && element.__location) {
         element.__startTagLocation = {
             start: element.__location.start,
             end: element.__location.end
         };
     }
-    if(endTagToken.location && endTagToken.type === Tokenizer.END_TAG_TOKEN && element.tagName === endTagToken.tagName) {
+    if (endTagToken.location &&
+        endTagToken.type === Tokenizer.END_TAG_TOKEN &&
+        element.tagName === endTagToken.tagName) {
         element.__endTagLocation = {
             start: endTagToken.location.start,
             end: endTagToken.location.end
@@ -108,7 +110,7 @@ exports.assign = function (parser) {
         //NOTE: _attachElementToTree is called from _appendElement, _insertElement and _insertTemplate methods.
         //So we will use token location stored in this methods for the element.
         element.__location = this.attachableElementLocation || null;
-        if(!element.__startTagLocation && element.__location) {
+        if (!element.__startTagLocation && element.__location) {
             element.__startTagLocation = {
                 start: element.__location.start,
                 end: element.__location.end

--- a/lib/tree_construction/location_info_mixin.js
+++ b/lib/tree_construction/location_info_mixin.js
@@ -10,8 +10,8 @@ var $ = HTML.TAG_NAMES;
 
 
 function setEndLocation(element, endTagToken) {
-    if (!element.__startTagLocation && element.__location) {
-        element.__startTagLocation = {
+    if (element.__location && !element.__location.startTag) {
+        element.__location.startTag = {
             start: element.__location.start,
             end: element.__location.end
         };
@@ -21,10 +21,11 @@ function setEndLocation(element, endTagToken) {
         endTagToken.type === Tokenizer.END_TAG_TOKEN &&
         //For cases like <td> <p> </td> - 'p' closes without a closing tag
         element.tagName === endTagToken.tagName) {
-        element.__endTagLocation = {
-            start: endTagToken.location.start,
-            end: endTagToken.location.end
-        };
+        if (element.__location)
+            element.__location.endTag = {
+                start: endTagToken.location.start,
+                end: endTagToken.location.end
+            };
     }
     if (element.__location && endTagToken.location)
         element.__location.end = endTagToken.location.end;

--- a/lib/tree_construction/location_info_mixin.js
+++ b/lib/tree_construction/location_info_mixin.js
@@ -17,7 +17,9 @@ function setEndLocation(element, endTagToken) {
         };
     }
     if (endTagToken.location &&
+        //For cases like <p> <p> </p> - First 'p' closes without a closing tag
         endTagToken.type === Tokenizer.END_TAG_TOKEN &&
+        //For cases like <td> <p> </td> - 'p' closes without a closing tag
         element.tagName === endTagToken.tagName) {
         element.__endTagLocation = {
             start: endTagToken.location.start,

--- a/lib/tree_construction/location_info_mixin.js
+++ b/lib/tree_construction/location_info_mixin.js
@@ -112,12 +112,6 @@ exports.assign = function (parser) {
         //NOTE: _attachElementToTree is called from _appendElement, _insertElement and _insertTemplate methods.
         //So we will use token location stored in this methods for the element.
         element.__location = this.attachableElementLocation || null;
-        if (!element.__startTagLocation && element.__location) {
-            element.__startTagLocation = {
-                start: element.__location.start,
-                end: element.__location.end
-            };
-        }
         this.attachableElementLocation = null;
         parserProto._attachElementToTree.call(this, element);
     };

--- a/lib/tree_construction/location_info_mixin.js
+++ b/lib/tree_construction/location_info_mixin.js
@@ -10,7 +10,19 @@ var $ = HTML.TAG_NAMES;
 
 
 function setEndLocation(element, endTagToken) {
-    if (element.__location)
+    if(!element.__startTagLocation && element.__location) {
+        element.__startTagLocation = {
+            start: element.__location.start,
+            end: element.__location.end
+        };
+    }
+    if(endTagToken.location && endTagToken.type === Tokenizer.END_TAG_TOKEN && element.tagName === endTagToken.tagName) {
+        element.__endTagLocation = {
+            start: endTagToken.location.start,
+            end: endTagToken.location.end
+        };
+    }
+    if (element.__location && endTagToken.location)
         element.__location.end = endTagToken.location.end;
 }
 
@@ -96,6 +108,12 @@ exports.assign = function (parser) {
         //NOTE: _attachElementToTree is called from _appendElement, _insertElement and _insertTemplate methods.
         //So we will use token location stored in this methods for the element.
         element.__location = this.attachableElementLocation || null;
+        if(!element.__startTagLocation && element.__location) {
+            element.__startTagLocation = {
+                start: element.__location.start,
+                end: element.__location.end
+            };
+        }
         this.attachableElementLocation = null;
         parserProto._attachElementToTree.call(this, element);
     };

--- a/test/fixtures/parser_test.js
+++ b/test/fixtures/parser_test.js
@@ -79,6 +79,30 @@ TestUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
                     //NOTE: use ok assertion, so output will not be polluted by the whole content of the strings
                     assert.ok(actual === expected, TestUtils.getStringDiffMsg(actual, expected));
+
+                    if (node.__location.startTag) {
+                        //NOTE: Based on the idea that the serialized fragment starts with the startTag
+                        var length = node.__location.startTag.end - node.__location.startTag.start,
+                            expectedStartTag = serializer.serialize(fragment).substring(0, length),
+                            actualStartTag = html.substring(node.__location.startTag.start, node.__location.startTag.end);
+
+                        expectedStartTag = TestUtils.removeNewLines(expectedStartTag);
+                        actualStartTag = TestUtils.removeNewLines(actualStartTag);
+
+                        assert.ok(expectedStartTag === actualStartTag, TestUtils.getStringDiffMsg(actualStartTag, expectedStartTag));
+                    }
+
+                    if (node.__location.endTag) {
+                        //NOTE: Based on the idea that the serialized fragment ends with the endTag
+                        var length = node.__location.endTag.end - node.__location.endTag.start,
+                            expectedEndTag = serializer.serialize(fragment).slice(-length),
+                            actualEndTag = html.substring(node.__location.endTag.start, node.__location.endTag.end);
+
+                        expectedEndTag = TestUtils.removeNewLines(expectedEndTag);
+                        actualEndTag = TestUtils.removeNewLines(actualEndTag);
+
+                        assert.ok(expectedEndTag === actualEndTag, TestUtils.getStringDiffMsg(actualEndTag, expectedEndTag));
+                    }
                 }
             });
         };


### PR DESCRIPTION
The parser, as of now only provides location information for a complete block, and not for the individual tags.
In my case needed location for both, start and end tags separately. Some other people might as well need it.
These are the minimum changes that I felt were required to make that happen. The tag locations can be accessed using __startTagLocation and __endTagLocation respectively.
Kindly review
Thanks! 