### PR TITLE
grammar fix in api docs

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -21,7 +21,7 @@ var $ = HTML.TAG_NAMES,
  * @typedef {Object} ParserOptions
  *
  * @property {Boolean} [decodeHtmlEntities=true] - Decode HTML-entities like `&amp;`, `&nbsp;`, etc.
- * **Warning:** disabling this option may cause output which is not conform HTML5 specification.
+ * **Warning:** disabling this option may result in output that does not conform to the HTML5 specification.
  *
  * @property {Boolean} [locationInfo=false] - Enables source code location information for the nodes.
  * When enabled, each node (except root node) has `__location` property. In case the node is not an empty element,

--- a/lib/serializer/index.js
+++ b/lib/serializer/index.js
@@ -14,7 +14,7 @@ var $ = HTML.TAG_NAMES,
  * @typedef {Object} SerializerOptions
  *
  * @property {Boolean} [encodeHtmlEntities=true] - HTML-encode characters like `<`, `>`, `&`, etc.
- * **Warning:** disabling this option may cause output which is not conform HTML5 specification.
+ * **Warning:** disabling this option may result in output that does not conform to the HTML5 specification.
  *
  * @property {TreeAdapter} [treeAdapter=parse5.treeAdapters.default] - Specifies input tree format.
  */


### PR DESCRIPTION
Minor change. I think that a link to a wiki page/etc explaining just how and what non-conformities can occur would be helpful. I'm even wondering as you read this.