### PR TITLE
Fix parseFragment with locationInfo regression when parsing <template…

### DIFF
--- a/lib/location_info/parser_mixin.js
+++ b/lib/location_info/parser_mixin.js
@@ -158,7 +158,7 @@ exports.assign = function (parser) {
         attachableElementLocation = token.location;
         parserProto._insertTemplate.call(this, token);
 
-        var tmplContent = this.treeAdapter.getChildNodes(this.openElements.current)[0];
+        var tmplContent = this.treeAdapter.getTemplateContent(this.openElements.current);
 
         tmplContent.__location = null;
     };

--- a/test/fixtures/location_info_parser_test.js
+++ b/test/fixtures/location_info_parser_test.js
@@ -130,4 +130,16 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
         assert.ok(fragment.childNodes[0].__location);
     };
+
+    exports['Regression - location info mixin error when parsing <template> elements (GH-90)'] = function () {
+        var html = '<template>hello</template>',
+            opts = {
+                treeAdapter: treeAdapter,
+                locationInfo: true
+            };
+
+        assert.doesNotThrow(function () {
+            parse5.parseFragment(html, opts);
+        });
+    };
 });


### PR DESCRIPTION
…> (fix #90)

Fixes #90. Introduces a new method for tree adaptors: `getTemplateContent`.