### PR TITLE
Location info for Attributes (2.0)

### DIFF
--- a/docs/05_api_reference.md
+++ b/docs/05_api_reference.md
@@ -8,6 +8,8 @@
 <dl>
 <dt><a href="#ElementLocationInfo">ElementLocationInfo</a> : <code>Object</code></dt>
 <dd></dd>
+<dt><a href="#TagLocationInfo">TagLocationInfo</a> : <code>Object</code></dt>
+<dd></dd>
 <dt><a href="#LocationInfo">LocationInfo</a> : <code>Object</code></dt>
 <dd></dd>
 <dt><a href="#ParserOptions">ParserOptions</a> : <code>Object</code></dt>
@@ -55,7 +57,8 @@
 
 <a name="new_parse5+ParserStream_new"></a>
 #### new ParserStream(options)
-Streaming HTML parser with scripting support.A [writable stream](https://nodejs.org/api/stream.html#stream_class_stream_writable).
+Streaming HTML parser with scripting support.
+A [writable stream](https://nodejs.org/api/stream.html#stream_class_stream_writable).
 
 
 | Param | Type | Description |
@@ -64,7 +67,19 @@ Streaming HTML parser with scripting support.A [writable stream](https://nodejs
 
 **Example**  
 ```js
-var parse5 = require('parse5');var http = require('http');// Fetch the google.com content and obtain it's <body> nodehttp.get('http://google.com', function(res) { var parser = new parse5.ParserStream(); parser.on('finish', function() {     var body = parser.document.childNodes[0].childNodes[1]; }); res.pipe(parser);});
+var parse5 = require('parse5');
+var http = require('http');
+
+// Fetch the google.com content and obtain it's <body> node
+http.get('http://google.com', function(res) {
+ var parser = new parse5.ParserStream();
+
+ parser.on('finish', function() {
+     var body = parser.document.childNodes[0].childNodes[1];
+ });
+
+ res.pipe(parser);
+});
 ```
 <a name="parse5+ParserStream+document"></a>
 #### parserStream.document : <code>ASTNode.&lt;document&gt;</code>
@@ -73,7 +88,9 @@ The resulting document node.
 **Kind**: instance property of <code>[ParserStream](#parse5+ParserStream)</code>  
 <a name="parse5+ParserStream+event_script"></a>
 #### "script" (scriptElement, documentWrite(html), resume)
-Raised then parser encounters a `<script>` element.If this event has listeners, parsing will be suspended once it is emitted.So, if `<script>` has the `src` attribute, you can fetch it, execute and then resume parsing just like browsers do.
+Raised then parser encounters a `<script>` element.
+If this event has listeners, parsing will be suspended once it is emitted.
+So, if `<script>` has the `src` attribute, you can fetch it, execute and then resume parsing just like browsers do.
 
 **Kind**: event emitted by <code>[ParserStream](#parse5+ParserStream)</code>  
 
@@ -85,7 +102,24 @@ Raised then parser encounters a `<script>` element.If this event has listeners,
 
 **Example**  
 ```js
-var parse = require('parse5');var http = require('http');var parser = new parse5.ParserStream();parser.on('script', function(scriptElement, documentWrite, resume) {  var src = parse5.treeAdapters.default.getAttrList(scriptElement)[0].value;  http.get(src, function(res) {     // Fetch the script content, execute it with DOM built around `parser.document` and     // `document.write` implemented using `documentWrite`.     ...     // Then resume parsing.     resume();  });});parser.end('<script src="example.com/script.js"></script>');
+var parse = require('parse5');
+var http = require('http');
+
+var parser = new parse5.ParserStream();
+
+parser.on('script', function(scriptElement, documentWrite, resume) {
+  var src = parse5.treeAdapters.default.getAttrList(scriptElement)[0].value;
+
+  http.get(src, function(res) {
+     // Fetch the script content, execute it with DOM built around `parser.document` and
+     // `document.write` implemented using `documentWrite`.
+     ...
+     // Then resume parsing.
+     resume();
+  });
+});
+
+parser.end('<script src="example.com/script.js"></script>');
 ```
 <a name="parse5+SAXParser"></a>
 ### parse5.SAXParser ⇐ <code>stream.Transform</code>
@@ -103,7 +137,9 @@ var parse = require('parse5');var http = require('http');var parser = new par
 
 <a name="new_parse5+SAXParser_new"></a>
 #### new SAXParser(options)
-Streaming [SAX](https://en.wikipedia.org/wiki/Simple_API_for_XML)-style HTML parser.A [transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform)(which means you can pipe *through* it, see example).
+Streaming [SAX](https://en.wikipedia.org/wiki/Simple_API_for_XML)-style HTML parser.
+A [transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform)
+(which means you can pipe *through* it, see example).
 
 
 | Param | Type | Description |
@@ -112,16 +148,51 @@ Streaming [SAX](https://en.wikipedia.org/wiki/Simple_API_for_XML)-style HTML par
 
 **Example**  
 ```js
-var parse5 = require('parse5');var http = require('http');var fs = require('fs');var file = fs.createWriteStream('/home/google.com.html');var parser = new parse5.SAXParser();parser.on('text', function(text) { // Handle page text content ...});http.get('http://google.com', function(res) { // SAXParser is the Transform stream, which means you can pipe // through it. So, you can analyze page content and, e.g., save it // to the file at the same time: res.pipe(parser).pipe(file);});
+var parse5 = require('parse5');
+var http = require('http');
+var fs = require('fs');
+
+var file = fs.createWriteStream('/home/google.com.html');
+var parser = new parse5.SAXParser();
+
+parser.on('text', function(text) {
+ // Handle page text content
+ ...
+});
+
+http.get('http://google.com', function(res) {
+ // SAXParser is the Transform stream, which means you can pipe
+ // through it. So, you can analyze page content and, e.g., save it
+ // to the file at the same time:
+ res.pipe(parser).pipe(file);
+});
 ```
 <a name="parse5+SAXParser+stop"></a>
 #### saxParser.stop()
-Stops parsing. Useful if you want the parser to stop consuming CPU time once you've obtained the desired infofrom the input stream. Doesn't prevent piping, so that data will flow through the parser as usual.
+Stops parsing. Useful if you want the parser to stop consuming CPU time once you've obtained the desired info
+from the input stream. Doesn't prevent piping, so that data will flow through the parser as usual.
 
 **Kind**: instance method of <code>[SAXParser](#parse5+SAXParser)</code>  
 **Example**  
 ```js
-var parse5 = require('parse5');var http = require('http');var fs = require('fs');var file = fs.createWriteStream('/home/google.com.html');var parser = new parse5.SAXParser();parser.on('doctype', function(name, publicId, systemId) { // Process doctype info ans stop parsing ... parser.stop();});http.get('http://google.com', function(res) { // Despite the fact that parser.stop() was called whole // content of the page will be written to the file res.pipe(parser).pipe(file);});
+var parse5 = require('parse5');
+var http = require('http');
+var fs = require('fs');
+
+var file = fs.createWriteStream('/home/google.com.html');
+var parser = new parse5.SAXParser();
+
+parser.on('doctype', function(name, publicId, systemId) {
+ // Process doctype info ans stop parsing
+ ...
+ parser.stop();
+});
+
+http.get('http://google.com', function(res) {
+ // Despite the fact that parser.stop() was called whole
+ // content of the page will be written to the file
+ res.pipe(parser).pipe(file);
+});
 ```
 <a name="parse5+SAXParser+event_startTag"></a>
 #### "startTag" (name, attributes, selfClosing, [location])
@@ -134,7 +205,7 @@ Raised when the parser encounters a start tag.
 | name | <code>String</code> | Tag name. |
 | attributes | <code>String</code> | List of attributes in the `{ key: String, value: String }` form. |
 | selfClosing | <code>Boolean</code> | Indicates if the tag is self-closing. |
-| [location] | <code>[LocationInfo](#LocationInfo)</code> | Start tag source code location info. Available if location info is enabled in [SAXParserOptions](#SAXParserOptions). |
+| [location] | <code>[TagLocationInfo](#TagLocationInfo)</code> | Start tag source code location info. Available if location info is enabled in [SAXParserOptions](#SAXParserOptions). |
 
 <a name="parse5+SAXParser+event_endTag"></a>
 #### "endTag" (name, [location])
@@ -145,7 +216,7 @@ Raised then parser encounters an end tag.
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>String</code> | Tag name. |
-| [location] | <code>[LocationInfo](#LocationInfo)</code> | End tag source code location info. Available if location info is enabled in [SAXParserOptions](#SAXParserOptions). |
+| [location] | <code>[TagLocationInfo](#TagLocationInfo)</code> | End tag source code location info. Available if location info is enabled in [SAXParserOptions](#SAXParserOptions). |
 
 <a name="parse5+SAXParser+event_comment"></a>
 #### "comment" (text, [location])
@@ -304,8 +375,20 @@ var bodyInnerHtml = parse5.serialize(document.childNodes[0].childNodes[1]);
 
 | Name | Type | Description |
 | --- | --- | --- |
-| startTag | <code>[LocationInfo](#LocationInfo)</code> | Element's start tag [LocationInfo](#LocationInfo). |
-| endTag | <code>[LocationInfo](#LocationInfo)</code> | Element's end tag [LocationInfo](#LocationInfo). |
+| startTag | <code>[TagLocationInfo](#TagLocationInfo)</code> | Element's start tag [TagLocationInfo](#TagLocationInfo). |
+| endTag | <code>[TagLocationInfo](#TagLocationInfo)</code> | Element's end tag [TagLocationInfo](#TagLocationInfo). |
+| [attrs] | <code>Object</code> | Contains the [LocationInfo](#LocationInfo) for all attributes on the element. |
+
+<a name="TagLocationInfo"></a>
+## TagLocationInfo : <code>Object</code>
+
+**Kind**: global typedef  
+**Extends:** <code>[LocationInfo](#LocationInfo)</code>  
+**Properties**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| [attrs] | <code>Object</code> | Contains the [LocationInfo](#LocationInfo) for all attributes on a startTag. |
 
 <a name="LocationInfo"></a>
 ## LocationInfo : <code>Object</code>

--- a/lib/location_info/parser_mixin.js
+++ b/lib/location_info/parser_mixin.js
@@ -29,6 +29,8 @@ function setEndLocation(element, closingToken, treeAdapter) {
             startOffset: loc.startOffset,
             endOffset: loc.endOffset
         };
+        if (loc.attrs)
+            loc.startTag.attrs = loc.attrs;
     }
 
     if (closingToken.location) {

--- a/lib/location_info/tokenizer_mixin.js
+++ b/lib/location_info/tokenizer_mixin.js
@@ -92,6 +92,26 @@ exports.assign = function (tokenizer) {
         attachLocationInfo(this.currentCharacterToken);
     };
 
+    tokenizer._createAttr = function (attrNameFirstCh) {
+        tokenizerProto._createAttr.call(this, attrNameFirstCh);
+        this.currentAttrLocation = {
+            line: line,
+            col: col,
+            startOffset: this.preprocessor.pos,
+            endOffset: -1
+        };
+    };
+
+    tokenizer._leaveAttrValue = function (toState) {
+        tokenizerProto._leaveAttrValue.call(this, toState);
+        this.currentAttrLocation.endOffset = this.preprocessor.pos;
+
+        if (!this.currentToken.location.attrs)
+            this.currentToken.location.attrs = {};
+
+        this.currentToken.location.attrs[this.currentAttr.name] = this.currentAttrLocation;
+    };
+
     //NOTE: patch token emission methods to determine end location
     tokenizer._emitCurrentToken = function () {
         //NOTE: if we have pending character token make it's end location equal to the

--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -388,6 +388,10 @@ Tokenizer.prototype._leaveAttrName = function (toState) {
         this.currentToken.attrs.push(this.currentAttr);
 };
 
+Tokenizer.prototype._leaveAttrValue = function (toState) {
+    this.state = toState;
+};
+
 //Appropriate end tag token
 //(see: http://www.whatwg.org/specs/web-apps/current-work/multipage/tokenization.html#appropriate-end-tag-token)
 Tokenizer.prototype._isAppropriateEndTagToken = function () {
@@ -1572,7 +1576,7 @@ _[ATTRIBUTE_VALUE_SINGLE_QUOTED_STATE] = function attributeValueSingleQuotedStat
 //------------------------------------------------------------------
 _[ATTRIBUTE_VALUE_UNQUOTED_STATE] = function attributeValueUnquotedState(cp) {
     if (isWhitespace(cp))
-        this.state = BEFORE_ATTRIBUTE_NAME_STATE;
+        this._leaveAttrValue(BEFORE_ATTRIBUTE_NAME_STATE);
 
     else if (cp === $.AMPERSAND) {
         this.additionalAllowedCp = $.GREATER_THAN_SIGN;
@@ -1581,7 +1585,7 @@ _[ATTRIBUTE_VALUE_UNQUOTED_STATE] = function attributeValueUnquotedState(cp) {
     }
 
     else if (cp === $.GREATER_THAN_SIGN) {
-        this.state = DATA_STATE;
+        this._leaveAttrValue(DATA_STATE);
         this._emitCurrentToken();
     }
 
@@ -1622,13 +1626,13 @@ _[CHARACTER_REFERENCE_IN_ATTRIBUTE_VALUE_STATE] = function characterReferenceInA
 //------------------------------------------------------------------
 _[AFTER_ATTRIBUTE_VALUE_QUOTED_STATE] = function afterAttributeValueQuotedState(cp) {
     if (isWhitespace(cp))
-        this.state = BEFORE_ATTRIBUTE_NAME_STATE;
+        this._leaveAttrValue(BEFORE_ATTRIBUTE_NAME_STATE);
 
     else if (cp === $.SOLIDUS)
-        this.state = SELF_CLOSING_START_TAG_STATE;
+        this._leaveAttrValue(SELF_CLOSING_START_TAG_STATE);
 
     else if (cp === $.GREATER_THAN_SIGN) {
-        this.state = DATA_STATE;
+        this._leaveAttrValue(DATA_STATE);
         this._emitCurrentToken();
     }
 

--- a/test/benchmark/bench-huge.js
+++ b/test/benchmark/bench-huge.js
@@ -7,7 +7,7 @@ var path = require('path'),
 //HACK: https://github.com/bestiejs/benchmark.js/issues/51
 /* global workingCopy, upstreamParser, hugePage */
 global.workingCopy = require('../../lib');
-global.upstreamParser = new upstreamParse5.Parser();
+global.upstreamParser = upstreamParse5;
 global.hugePage = fs.readFileSync(path.join(__dirname, '../data/huge-page/huge-page.html')).toString();
 
 module.exports = {

--- a/test/benchmark/bench-micro.js
+++ b/test/benchmark/bench-micro.js
@@ -6,7 +6,7 @@ var path = require('path'),
 
 //HACK: https://github.com/bestiejs/benchmark.js/issues/51
 /* global upstreamParser, workingCopy, micro, runMicro */
-global.upstreamParser = new upstreamParse5.Parser();
+global.upstreamParser = upstreamParse5;
 global.workingCopy = require('../../lib');
 global.micro = testUtils
     .loadTreeConstructionTestData([path.join(__dirname, '../data/tree_construction')], workingCopy.treeAdapters.default)

--- a/test/benchmark/bench-pages.js
+++ b/test/benchmark/bench-pages.js
@@ -6,7 +6,7 @@ var path = require('path'),
 
 //HACK: https://github.com/bestiejs/benchmark.js/issues/51
 /* global upstreamParser, workingCopy, pages, runPages */
-global.upstreamParser = new upstreamParse5.Parser();
+global.upstreamParser = upstreamParse5;
 global.workingCopy = require('../../lib');
 global.pages = testUtils
     .loadSerializationTestData(path.join(__dirname, '../data/sax'))

--- a/test/benchmark/bench-stream.js
+++ b/test/benchmark/bench-stream.js
@@ -7,7 +7,7 @@ var path = require('path'),
 /* global fs, Promise, upstreamParser, workingCopy, files, deferred */
 global.fs = require('fs');
 global.Promise = require('promise');
-global.upstreamParser = new upstreamParse5.Parser();
+global.upstreamParser = upstreamParse5;
 global.workingCopy = require('../../lib');
 global.files = fs
     .readdirSync(path.join(__dirname, '../data/sax'))

--- a/test/fixtures/location_info_parser_test.js
+++ b/test/fixtures/location_info_parser_test.js
@@ -55,6 +55,14 @@ function assertEndTagLocation(node, serializedNode, html, lines) {
     assertLocation(node.__location.endTag, expected, html, lines);
 }
 
+function assertAttrsLocation(node, serializedNode, html, lines) {
+    node.__location.attrs.forEach(function (attr) {
+        var expected = serializedNode.slice(attr.startOffset, attr.endOffset);
+
+        assertLocation(attr, expected, html, lines);
+    });
+}
+
 function assertNodeLocation(node, serializedNode, html, lines) {
     var expected = testUtils.removeNewLines(serializedNode);
 
@@ -98,6 +106,9 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
                         if (node.__location.endTag)
                             assertEndTagLocation(node, serializedNode, html, lines);
+
+                        if (node.__location.attrs)
+                            assertAttrsLocation(node, serializedNode, html, lines);
                     }
                 });
             };


### PR DESCRIPTION
This is based on the work by @sakagg in #59 , with additional changes that:

- based off the latest 2.0 master;
- attrs location info attached to both `node.__location` and `node.__location.startTag`, as suggested in [this comment](https://github.com/inikulin/parse5/pull/59#issuecomment-130285405);
- fixed and ran the regression benchmark with the following result (no significant perf regression):

<img width="907" alt="screen shot 2016-01-04 at 9 16 40 pm" src="https://cloud.githubusercontent.com/assets/499550/12105988/8a4ddcec-b328-11e5-8a2f-4c658b847fac.png">
