### PR TITLE
fix attribute location info for empty attributes

### DIFF
--- a/lib/location_info/tokenizer_mixin.js
+++ b/lib/location_info/tokenizer_mixin.js
@@ -102,8 +102,17 @@ exports.assign = function (tokenizer) {
         };
     };
 
+    tokenizer._leaveAttrName = function (toState) {
+        tokenizerProto._leaveAttrName.call(this, toState);
+        this._attachCurrentAttrLocationInfo();
+    };
+
     tokenizer._leaveAttrValue = function (toState) {
         tokenizerProto._leaveAttrValue.call(this, toState);
+        this._attachCurrentAttrLocationInfo();
+    };
+
+    tokenizer._attachCurrentAttrLocationInfo = function () {
         this.currentAttrLocation.endOffset = this.preprocessor.pos;
 
         if (!this.currentToken.location.attrs)

--- a/test/fixtures/location_info_parser_test.js
+++ b/test/fixtures/location_info_parser_test.js
@@ -153,4 +153,16 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
             parse5.parseFragment(html, opts);
         });
     };
+
+    exports['Regression - location info not attached for empty attributes'] = function () {
+        var html = '<div test-attr></div>',
+            opts = {
+                treeAdapter: treeAdapter,
+                locationInfo: true
+            };
+
+        var fragment = parse5.parseFragment(html, opts);
+
+        assert.ok(fragment.childNodes[0].__location.attrs['test-attr']);
+    };
 });


### PR DESCRIPTION
In my PR for attribute location I forgot to also overwrite `tokenizer._leaveAttrName` - which causes missing location info for attributes with no value.

For example, `<div some-attr></div>` would have an `attrs` array of length 1, but no `__location.attrs`.