### PR TITLE
Type check str param in escapeString method

### DIFF
--- a/lib/serializer/index.js
+++ b/lib/serializer/index.js
@@ -37,6 +37,9 @@ var Serializer = module.exports = function (node, options) {
 
 // NOTE: exported as static method for the testing purposes
 Serializer.escapeString = function (str, attrMode) {
+    if (typeof str !== 'string')
+        return str;
+
     str = str
         .replace(AMP_REGEX, '&amp;')
         .replace(NBSP_REGEX, '&nbsp;');


### PR DESCRIPTION
There was an issue where false | undefined | null were being passed into parse5 via angular2-universal. That caused `TypeError: str.replace is not a function` errors.