### PR TITLE
Fix attribute form for SAXParser 'startTag'

### DIFF
--- a/lib/sax/index.js
+++ b/lib/sax/index.js
@@ -163,7 +163,7 @@ SAXParser.prototype._handleToken = function (token) {
          * @instance
          * @type {Function}
          * @param {String} name - Tag name.
-         * @param {Array} attrs - List of attributes in the `{ key: String, value: String }` form.
+         * @param {Array} attrs - List of attributes in the `{ name: String, value: String, prefix?: String }` form.
          * @param {Boolean} selfClosing - Indicates if the tag is self-closing.
          * @param {StartTagLocationInfo} [location] - Start tag source code location info.
          * Available if location info is enabled in {@link SAXParserOptions}.


### PR DESCRIPTION
Add new optional prefix field