### PR TITLE
Fix line number calculation bug

### DIFF
--- a/lib/location_info/tokenizer_mixin.js
+++ b/lib/location_info/tokenizer_mixin.js
@@ -57,6 +57,7 @@ exports.assign = function (tokenizer) {
 
     tokenizer._unconsume = function () {
         tokenizerProto._unconsume.call(this);
+        isEol = false;
 
         while (lineStartPos > this.preprocessor.pos && lineStartPosStack.length > 1) {
             lineStartPos = lineStartPosStack.pop();

--- a/test/fixtures/location_info_parser_test.js
+++ b/test/fixtures/location_info_parser_test.js
@@ -165,4 +165,29 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
 
         assert.ok(fragment.childNodes[0].__location.attrs['test-attr']);
     };
+
+    exports['Regression - location line incorrect when a character is unconsumed (GH-151)'] = function () {
+        var html = ['<html><body>',
+            '<script>',
+            '  var x = window.scrollY <',
+            '      100;',
+            '</script>',
+            '</body></html>'].join('\n'),
+            opts = {
+                treeAdapter: treeAdapter,
+                locationInfo: true
+            };
+
+        var doc = parse5.parse(html, opts),
+            foundScript = false;
+
+        walkTree(doc, treeAdapter, function (node) {
+            if (node.name === 'script') {
+                foundScript = true;
+                assert.equal(node.__location.endTag.line, 5);
+            }
+        });
+
+        assert.ok(foundScript);
+    };
 });


### PR DESCRIPTION
When consuming tokens in script tags, a `<` right before a newline would cause the line number calculation to be offset by 1. Repo case:

```html
<!DOCTYPE html>
<html>
<body>
<script>
  var x = window.scrollY <
      100; //line number is now off by one
</script>
</html>
```

Simply setting the `isEol` flag to false when unconsuming a token corrects the issue.