### PR TITLE
fix(serializer): safe use of replace

### DIFF
--- a/lib/serializer/index.js
+++ b/lib/serializer/index.js
@@ -37,7 +37,7 @@ var Serializer = module.exports = function (node, options) {
 
 // NOTE: exported as static method for the testing purposes
 Serializer.escapeString = function (str, attrMode) {
-    str = str
+    str = (typeof str === 'string' ? str : String(str))
         .replace(AMP_REGEX, '&amp;')
         .replace(NBSP_REGEX, '&nbsp;');
 


### PR DESCRIPTION
when server-rendering angular2 apps using angular/universal I get str.replace is not a function error, debugging lead me here