### PR TITLE
Fixed incorrect LocationInfo.endOffset for non-implicitly closed elements

### DIFF
--- a/lib/location_info/parser_mixin.js
+++ b/lib/location_info/parser_mixin.js
@@ -50,7 +50,10 @@ function setEndLocation(element, closingToken, treeAdapter) {
             };
         }
 
-        loc.endOffset = ctLocation.startOffset;
+        if (isClosingEndTag)
+            loc.endOffset = ctLocation.endOffset;
+        else
+            loc.endOffset = ctLocation.startOffset;
     }
 }
 

--- a/test/fixtures/location_info_parser_test.js
+++ b/test/fixtures/location_info_parser_test.js
@@ -143,6 +143,18 @@ testUtils.generateTestsForEachTreeAdapter(module.exports, function (_test, treeA
         assert.strictEqual(html.substring(firstPLocation.startOffset, firstPLocation.endOffset), '<p>1');
     };
 
+    exports['Regression - Incorrect LocationInfo.endOffset for element with closing tag (GH-159)'] = function () {
+        var html = '<i>1</i>2',
+            opts = {
+                treeAdapter: treeAdapter,
+                locationInfo: true
+            };
+
+        var fragment = parse5.parseFragment(html, opts),
+            location = fragment.childNodes[0].__location;
+
+        assert.strictEqual(html.substring(location.startOffset, location.endOffset), '<i>1</i>');
+    };
 
     exports['Regression - Location info not exposed with parseFragment (GH-82)'] = function () {
         var html = '<html><head></head><body>foo</body></html>',


### PR DESCRIPTION
3a3515a seems to have introduced an error for all other elements (non-implicitly closed elements), as can be seen in the included test.

Kinda weird that it wasn’t caught before!

Cheers