### PR TITLE
Make sure attrs is defined on createElement()

### DIFF
--- a/lib/tree_adapters/default.js
+++ b/lib/tree_adapters/default.js
@@ -58,6 +58,7 @@ exports.createDocumentFragment = function () {
  *
  */
 exports.createElement = function (tagName, namespaceURI, attrs) {
+    if (!attrs) attrs = []
     return {
         nodeName: tagName,
         tagName: tagName,


### PR DESCRIPTION
 * fixes parse5.serialize() breaking on elements created via. the default treeAdapter