### PR TITLE
Move @types/node to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "publish-please": "^2.2.0",
     "through2": "^2.0.0",
     "typedoc": "^0.5.1",
-    "typescript": "^2.0.6"
+    "typescript": "^2.0.6",
+    "@types/node": "^6.0.46"
   },
   "keywords": [
     "html",
@@ -56,8 +57,5 @@
   },
   "files": [
     "lib"
-  ],
-  "dependencies": {
-    "@types/node": "^6.0.46"
-  }
+  ]
 }


### PR DESCRIPTION
Please make @types/node an development dependency so that it won't be installed when parse5 is used.