### PR TITLE
Escape NUL character in feedback tests

### DIFF
--- a/test/data/parser_feedback/domjs-unsafe.test
+++ b/test/data/parser_feedback/domjs-unsafe.test
@@ -46,7 +46,7 @@
             ]
         },
         {
-            "description": "<script>a='\u0000'</script>",
+            "description": "<script>a='\\u0000'</script>",
             "input": "<script>a='\u0000'</script>",
             "output": [
                 [
@@ -65,7 +65,7 @@
             ]
         },
         {
-            "description": "<script type=\"data\"><!--\u0000</script>",
+            "description": "<script type=\"data\"><!--\\u0000</script>",
             "input": "<script type=\"data\"><!--\u0000</script>",
             "output": [
                 [
@@ -86,7 +86,7 @@
             ]
         },
         {
-            "description": "<script type=\"data\"><!--foo\u0000</script>",
+            "description": "<script type=\"data\"><!--foo\\u0000</script>",
             "input": "<script type=\"data\"><!--foo\u0000</script>",
             "output": [
                 [
@@ -107,7 +107,7 @@
             ]
         },
         {
-            "description": "<script type=\"data\"><!-- foo-\u0000</script>",
+            "description": "<script type=\"data\"><!-- foo-\\u0000</script>",
             "input": "<script type=\"data\"><!-- foo-\u0000</script>",
             "output": [
                 [
@@ -128,7 +128,7 @@
             ]
         },
         {
-            "description": "<script type=\"data\"><!-- foo--\u0000</script>",
+            "description": "<script type=\"data\"><!-- foo--\\u0000</script>",
             "input": "<script type=\"data\"><!-- foo--\u0000</script>",
             "output": [
                 [
@@ -267,7 +267,7 @@
             ]
         },
         {
-            "description": "<script type=\"data\"><!--<script>\u0000</script></script>",
+            "description": "<script type=\"data\"><!--<script>\\u0000</script></script>",
             "input": "<script type=\"data\"><!--<script>\u0000</script></script>",
             "output": [
                 [
@@ -288,7 +288,7 @@
             ]
         },
         {
-            "description": "<script type=\"data\"><!--<script>-\u0000</script></script>",
+            "description": "<script type=\"data\"><!--<script>-\\u0000</script></script>",
             "input": "<script type=\"data\"><!--<script>-\u0000</script></script>",
             "output": [
                 [
@@ -309,7 +309,7 @@
             ]
         },
         {
-            "description": "<script type=\"data\"><!--<script>--\u0000</script></script>",
+            "description": "<script type=\"data\"><!--<script>--\\u0000</script></script>",
             "input": "<script type=\"data\"><!--<script>--\u0000</script></script>",
             "output": [
                 [

--- a/test/data/parser_feedback/pending-spec-changes-plain-text-unsafe.test
+++ b/test/data/parser_feedback/pending-spec-changes-plain-text-unsafe.test
@@ -1,7 +1,7 @@
 {
     "tests": [
         {
-            "description": "<body><table>\u0000filler\u0000text\u0000",
+            "description": "<body><table>\\u0000filler\\u0000text\\u0000",
             "input": "<body><table>\u0000filler\u0000text\u0000",
             "output": [
                 [

--- a/test/data/parser_feedback/plain-text-unsafe.test
+++ b/test/data/parser_feedback/plain-text-unsafe.test
@@ -11,7 +11,7 @@
             ]
         },
         {
-            "description": "<html>\u0000<frameset></frameset>",
+            "description": "<html>\\u0000<frameset></frameset>",
             "input": "<html>\u0000<frameset></frameset>",
             "output": [
                 [
@@ -35,7 +35,7 @@
             ]
         },
         {
-            "description": "<html> \u0000 <frameset></frameset>",
+            "description": "<html> \\u0000 <frameset></frameset>",
             "input": "<html> \u0000 <frameset></frameset>",
             "output": [
                 [
@@ -59,7 +59,7 @@
             ]
         },
         {
-            "description": "<html>a\u0000a<frameset></frameset>",
+            "description": "<html>a\\u0000a<frameset></frameset>",
             "input": "<html>a\u0000a<frameset></frameset>",
             "output": [
                 [
@@ -83,7 +83,7 @@
             ]
         },
         {
-            "description": "<html>\u0000\u0000<frameset></frameset>",
+            "description": "<html>\\u0000\\u0000<frameset></frameset>",
             "input": "<html>\u0000\u0000<frameset></frameset>",
             "output": [
                 [
@@ -107,7 +107,7 @@
             ]
         },
         {
-            "description": "<html>\u0000\\r\\n <frameset></frameset>",
+            "description": "<html>\\u0000\\r\\n <frameset></frameset>",
             "input": "<html>\u0000\r\n <frameset></frameset>",
             "output": [
                 [
@@ -131,7 +131,7 @@
             ]
         },
         {
-            "description": "<html><select>\u0000",
+            "description": "<html><select>\\u0000",
             "input": "<html><select>\u0000",
             "output": [
                 [
@@ -151,7 +151,7 @@
             ]
         },
         {
-            "description": "\u0000",
+            "description": "\\u0000",
             "input": "\u0000",
             "output": [
                 [
@@ -161,7 +161,7 @@
             ]
         },
         {
-            "description": "<body>\u0000",
+            "description": "<body>\\u0000",
             "input": "<body>\u0000",
             "output": [
                 [
@@ -176,7 +176,7 @@
             ]
         },
         {
-            "description": "<plaintext>\u0000filler\u0000text\u0000",
+            "description": "<plaintext>\\u0000filler\\u0000text\\u0000",
             "input": "<plaintext>\u0000filler\u0000text\u0000",
             "output": [
                 [
@@ -191,7 +191,7 @@
             ]
         },
         {
-            "description": "<svg><![CDATA[\u0000filler\u0000text\u0000]]>",
+            "description": "<svg><![CDATA[\\u0000filler\\u0000text\\u0000]]>",
             "input": "<svg><![CDATA[\u0000filler\u0000text\u0000]]>",
             "output": [
                 [
@@ -206,7 +206,7 @@
             ]
         },
         {
-            "description": "<body><!\u0000>",
+            "description": "<body><!\\u0000>",
             "input": "<body><!\u0000>",
             "output": [
                 [
@@ -221,7 +221,7 @@
             ]
         },
         {
-            "description": "<body><!\u0000filler\u0000text>",
+            "description": "<body><!\\u0000filler\\u0000text>",
             "input": "<body><!\u0000filler\u0000text>",
             "output": [
                 [
@@ -236,7 +236,7 @@
             ]
         },
         {
-            "description": "<body><svg><foreignObject>\u0000filler\u0000text",
+            "description": "<body><svg><foreignObject>\\u0000filler\\u0000text",
             "input": "<body><svg><foreignObject>\u0000filler\u0000text",
             "output": [
                 [
@@ -261,7 +261,7 @@
             ]
         },
         {
-            "description": "<svg>\u0000filler\u0000text",
+            "description": "<svg>\\u0000filler\\u0000text",
             "input": "<svg>\u0000filler\u0000text",
             "output": [
                 [
@@ -276,7 +276,7 @@
             ]
         },
         {
-            "description": "<svg>\u0000<frameset>",
+            "description": "<svg>\\u0000<frameset>",
             "input": "<svg>\u0000<frameset>",
             "output": [
                 [
@@ -296,7 +296,7 @@
             ]
         },
         {
-            "description": "<svg>\u0000 <frameset>",
+            "description": "<svg>\\u0000 <frameset>",
             "input": "<svg>\u0000 <frameset>",
             "output": [
                 [
@@ -316,7 +316,7 @@
             ]
         },
         {
-            "description": "<svg>\u0000a<frameset>",
+            "description": "<svg>\\u0000a<frameset>",
             "input": "<svg>\u0000a<frameset>",
             "output": [
                 [
@@ -336,7 +336,7 @@
             ]
         },
         {
-            "description": "<svg>\u0000</svg><frameset>",
+            "description": "<svg>\\u0000</svg><frameset>",
             "input": "<svg>\u0000</svg><frameset>",
             "output": [
                 [
@@ -360,7 +360,7 @@
             ]
         },
         {
-            "description": "<svg>\u0000 </svg><frameset>",
+            "description": "<svg>\\u0000 </svg><frameset>",
             "input": "<svg>\u0000 </svg><frameset>",
             "output": [
                 [
@@ -384,7 +384,7 @@
             ]
         },
         {
-            "description": "<svg>\u0000a</svg><frameset>",
+            "description": "<svg>\\u0000a</svg><frameset>",
             "input": "<svg>\u0000a</svg><frameset>",
             "output": [
                 [
@@ -536,7 +536,7 @@
             ]
         },
         {
-            "description": "<!DOCTYPE html><table><tr><td><math><mtext>\u0000a",
+            "description": "<!DOCTYPE html><table><tr><td><math><mtext>\\u0000a",
             "input": "<!DOCTYPE html><table><tr><td><math><mtext>\u0000a",
             "output": [
                 [
@@ -578,7 +578,7 @@
             ]
         },
         {
-            "description": "<!DOCTYPE html><table><tr><td><svg><foreignObject>\u0000a",
+            "description": "<!DOCTYPE html><table><tr><td><svg><foreignObject>\\u0000a",
             "input": "<!DOCTYPE html><table><tr><td><svg><foreignObject>\u0000a",
             "output": [
                 [
@@ -620,7 +620,7 @@
             ]
         },
         {
-            "description": "<!DOCTYPE html><math><mi>a\u0000b",
+            "description": "<!DOCTYPE html><math><mi>a\\u0000b",
             "input": "<!DOCTYPE html><math><mi>a\u0000b",
             "output": [
                 [
@@ -647,7 +647,7 @@
             ]
         },
         {
-            "description": "<!DOCTYPE html><math><mo>a\u0000b",
+            "description": "<!DOCTYPE html><math><mo>a\\u0000b",
             "input": "<!DOCTYPE html><math><mo>a\u0000b",
             "output": [
                 [
@@ -674,7 +674,7 @@
             ]
         },
         {
-            "description": "<!DOCTYPE html><math><mn>a\u0000b",
+            "description": "<!DOCTYPE html><math><mn>a\\u0000b",
             "input": "<!DOCTYPE html><math><mn>a\u0000b",
             "output": [
                 [
@@ -701,7 +701,7 @@
             ]
         },
         {
-            "description": "<!DOCTYPE html><math><ms>a\u0000b",
+            "description": "<!DOCTYPE html><math><ms>a\\u0000b",
             "input": "<!DOCTYPE html><math><ms>a\u0000b",
             "output": [
                 [
@@ -728,7 +728,7 @@
             ]
         },
         {
-            "description": "<!DOCTYPE html><math><mtext>a\u0000b",
+            "description": "<!DOCTYPE html><math><mtext>a\\u0000b",
             "input": "<!DOCTYPE html><math><mtext>a\u0000b",
             "output": [
                 [

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -11,7 +11,8 @@ function addSlashes(str) {
         .replace(/\t/g, '\\t')
         .replace(/\n/g, '\\n')
         .replace(/\f/g, '\\f')
-        .replace(/\r/g, '\\r');
+        .replace(/\r/g, '\\r')
+        .replace(/\0/g, '\\u0000');
 }
 
 exports.addSlashes = addSlashes;


### PR DESCRIPTION
Previously, this character was invisible in the test output.
Escaping as `\u0000` and not just `\0` for consistency with other tests.