### PR TITLE
Add preserveCase option.

### DIFF
--- a/lib/tokenizer/index.js
+++ b/lib/tokenizer/index.js
@@ -143,8 +143,9 @@ function toChar(cp) {
     cp -= 0x10000;
     return String.fromCharCode(cp >>> 10 & 0x3FF | 0xD800) + String.fromCharCode(0xDC00 | cp & 0x3FF);
 }
-
+let preserveCase = false;
 function toAsciiLowerChar(cp) {
+    if (preserveCase) return toChar(cp);
     return String.fromCharCode(toAsciiLowerCodePoint(cp));
 }
 
@@ -172,9 +173,11 @@ function findNamedEntityTreeBranch(nodeIx, cp) {
 
 
 //Tokenizer
-var Tokenizer = module.exports = function () {
+var Tokenizer = module.exports = function (options) {
     this.preprocessor = new Preprocessor();
 
+    if (options.options['preserveCase']) preserveCase = true;
+    
     this.tokenQueue = [];
 
     this.allowCDATA = false;


### PR DESCRIPTION
I needed to be able to preserve the attribute case for a SAX application I am writing. This pull request implements that change by modifying the `toAsciiLowerChar` function to return the result of `toChar` if a preserveCase option is set.

To eliminate the `if (preserveCase) {` test we could have a function pointer that is swapped between toAsciiLowerChar function and toChar function so there is just one test on initialization of the module. I can do another pull request with that option if it is interesting.
