### PR TITLE
Move @types/node from runtime deps to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
   "homepage": "https://github.com/inikulin/parse5",
   "devDependencies": {
+    "@types/node": "*",    
     "del": "^2.0.2",
     "gulp": "^3.9.0",
     "gulp-benchmark": "^1.1.1",
@@ -58,6 +59,5 @@
     "lib"
   ],
   "dependencies": {
-    "@types/node": "*"
   }
 }


### PR DESCRIPTION
**Problem**
Using Enzyme in React Native projects causes TypeScript builds to fail with error:

    node_modules/@types/node/index.d.ts(138,13): error TS2300: Duplicate identifier 'require'.
    node_modules/@types/react-native/index.d.ts(8598,14): error TS2300: Duplicate identifier 'require'.

**Cause**
Enzyme lists @types/node as a runtime dependency that gets installed with the NPM package into consuming projects.  @types/node conflicts with the types provided in React Native projects and possibly other project types.  This runtime dependency should actually be a dev dependency unless there is some legit reason that this dependency needs to be force-installed into consuming projects.

**Resolution**
Moved @types/node from dependencies to devDependencies.

**Dependency Chain**
- https://www.npmjs.com/package/enzyme
- https://www.npmjs.com/package/cheerio
- https://www.npmjs.com/package/parse5