### PR TITLE
Lock @types/node version to ^8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "lib"
   ],
   "dependencies": {
-    "@types/node": "*"
+    "@types/node": "^8.x"
   }
 }


### PR DESCRIPTION
Previous syntax to specify this package's version unintentionally installs previous version in terms of semantic versioning.
This is because definition of `latest version` in NPM is the latest version in **chronological** order.
For example, if a package releases version 1.1.0 after releasing 2.0.0, package-name: '*' installs 1.1.0,
which @types/node often does.
This commit makes sure we will keep depending on 8.x.x version of @types/node.

```
hfukui@linuxmint ~/Projects/parse5 $ npm install
...
> publish-please@2.3.1 postinstall /home/hfukui/Projects/parse5/node_modules/publish-please
> node lib/init.js


> parse5@3.0.3 prepublish /home/hfukui/Projects/parse5
> publish-please guard

parse5@3.0.3 /home/hfukui/Projects/parse5
├── @types/node@8.5.5 
├─┬ del@2.2.2 
│ ├─┬ globby@5.0.0 
...
```