### PR TITLE
Add "types" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   ],
   "license": "MIT",
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/inikulin/parse5.git"


### PR DESCRIPTION
For some reason TypeScript has a problem resolving the type declarations in subdirectories.

```
src/index.ts(3,25): error TS7016: Could not find a declaration file for module 'parse5'. '/Users/klaus/code/wotan/node_modules/parse5/lib/index.js' implicitly has an 'any' type.
  Try `npm install @types/parse5` if it exists or add a new declaration (.d.ts) file containing `declare module 'parse5';`
```

This forces me to import directly from `parse5/lib`.

By adding `"types"` to the package.json everything works as expected.