### PR TITLE
parser-stream docs: parens required when destructuring parameter

### DIFF
--- a/packages/parse5-parser-stream/docs/index.md
+++ b/packages/parse5-parser-stream/docs/index.md
@@ -88,7 +88,7 @@ const http = require('http');
 const parser = new ParserStream();
 
 parser.on('script', (scriptElement, documentWrite, resume) => {
-    const src = scriptElement.attrs.find({ name } => name === 'src').value;
+    const src = scriptElement.attrs.find(({ name }) => name === 'src').value;
 
     http.get(src, res => {
         // Fetch the script content, execute it with DOM built around `parser.document` and


### PR DESCRIPTION
Fixes a typo in an example in the docs for parse5-parser-stream.