### PR TITLE
Refactor emission logic of SAXParser and RewritingStream

### DIFF
--- a/packages/parse5-html-rewriting-stream/lib/index.js
+++ b/packages/parse5-html-rewriting-stream/lib/index.js
@@ -16,10 +16,10 @@ class RewritingStream extends SAXParser {
         callback();
     }
 
-    _getCurrentTokenRawHtml() {
+    _getRawHtml(location) {
         const droppedBufferSize = this.posTracker.droppedBufferSize;
-        const start = this.currentTokenLocation.startOffset - droppedBufferSize;
-        const end = this.currentTokenLocation.endOffset - droppedBufferSize;
+        const start = location.startOffset - droppedBufferSize;
+        const end = location.endOffset - droppedBufferSize;
 
         return this.tokenizer.preprocessor.html.slice(start, end);
     }
@@ -27,7 +27,7 @@ class RewritingStream extends SAXParser {
     // Events
     _handleToken(token) {
         if (!super._handleToken(token)) {
-            this.emitRaw(this._getCurrentTokenRawHtml());
+            this.emitRaw(this._getRawHtml(token.location));
         }
 
         // NOTE: don't skip new lines after <pre> and other tags,
@@ -37,7 +37,7 @@ class RewritingStream extends SAXParser {
 
     // Emitter API
     _emitToken(eventName, token) {
-        this.emit(eventName, token, this._getCurrentTokenRawHtml());
+        this.emit(eventName, token, this._getRawHtml(token.sourceCodeLocation));
     }
 
     emitDoctype(token) {

--- a/packages/parse5-html-rewriting-stream/lib/index.js
+++ b/packages/parse5-html-rewriting-stream/lib/index.js
@@ -10,10 +10,10 @@ class RewritingStream extends SAXParser {
         this.posTracker = this.locInfoMixin.posTracker;
     }
 
-    _transform(chunk, encoding, callback) {
-        this._parseChunk(chunk);
-
-        callback();
+    _transformChunk(chunk) {
+        // NOTE: ignore upstream return value as we want to push to
+        // the Writable part of Transform stream ourselves.
+        super._transformChunk(chunk);
     }
 
     _getRawHtml(location) {

--- a/packages/parse5-sax-parser/lib/index.js
+++ b/packages/parse5-sax-parser/lib/index.js
@@ -115,7 +115,7 @@ class SAXParser extends Transform {
             return false;
         }
 
-        this._emitToken(eventName, reshapeToken.call(this, token));
+        this._emitToken(eventName, reshapeToken(token));
 
         return true;
     }
@@ -130,59 +130,38 @@ class SAXParser extends Transform {
             this.pendingText = null;
         }
     }
-
-    // Tokens
-    _reshapeStartTagToken(origToken) {
-        return {
-            tagName: origToken.tagName,
-            attrs: origToken.attrs,
-            selfClosing: origToken.selfClosing,
-            sourceCodeLocation: origToken.location
-        };
-    }
-
-    _reshapeEndTagToken(origToken) {
-        return { tagName: origToken.tagName, sourceCodeLocation: origToken.location };
-    }
-
-    _reshapeCommentToken(origToken) {
-        return { text: origToken.data, sourceCodeLocation: origToken.location };
-    }
-
-    _reshapeDoctypeToken(origToken) {
-        return {
-            name: origToken.name,
-            publicId: origToken.publicId,
-            systemId: origToken.systemId,
-            sourceCodeLocation: origToken.location
-        };
-    }
-
-    _reshapeCharToken(origToken) {
-        return { text: origToken.chars, sourceCodeLocation: origToken.location };
-    }
 }
 
 const TOKEN_EMISSION_HELPERS = {
     [Tokenizer.START_TAG_TOKEN]: {
         eventName: 'startTag',
-        reshapeToken: SAXParser.prototype._reshapeStartTagToken
+        reshapeToken: origToken => ({
+            tagName: origToken.tagName,
+            attrs: origToken.attrs,
+            selfClosing: origToken.selfClosing,
+            sourceCodeLocation: origToken.location
+        })
     },
     [Tokenizer.END_TAG_TOKEN]: {
         eventName: 'endTag',
-        reshapeToken: SAXParser.prototype._reshapeEndTagToken
+        reshapeToken: origToken => ({ tagName: origToken.tagName, sourceCodeLocation: origToken.location })
     },
     [Tokenizer.COMMENT_TOKEN]: {
         eventName: 'comment',
-        reshapeToken: SAXParser.prototype._reshapeCommentToken
+        reshapeToken: origToken => ({ text: origToken.data, sourceCodeLocation: origToken.location })
     },
     [Tokenizer.DOCTYPE_TOKEN]: {
         eventName: 'doctype',
-        reshapeToken: SAXParser.prototype._reshapeDoctypeToken
+        reshapeToken: origToken => ({
+            name: origToken.name,
+            publicId: origToken.publicId,
+            systemId: origToken.systemId,
+            sourceCodeLocation: origToken.location
+        })
     },
     [Tokenizer.CHARACTER_TOKEN]: {
         eventName: 'text',
-        reshapeToken: SAXParser.prototype._reshapeCharToken
+        reshapeToken: origToken => ({ text: origToken.chars, sourceCodeLocation: origToken.location })
     }
 };
 

--- a/packages/parse5-sax-parser/lib/index.js
+++ b/packages/parse5-sax-parser/lib/index.js
@@ -87,7 +87,12 @@ class SAXParser extends Transform {
                     if (this.pendingText === null) {
                         this.currentTokenLocation = token.location;
                     } else {
-                        this.currentTokenLocation.endOffset = token.location.endOffset;
+                        const { endLine, endCol, endOffset } = token.location;
+                        Object.assign(this.currentTokenLocation, {
+                            endLine,
+                            endCol,
+                            endOffset
+                        });
                     }
                 }
 

--- a/packages/parse5-sax-parser/lib/index.js
+++ b/packages/parse5-sax-parser/lib/index.js
@@ -40,10 +40,7 @@ class SAXParser extends Transform {
 
     //TransformStream implementation
     _transform(chunk, encoding, callback) {
-        this._parseChunk(chunk);
-        this.push(chunk);
-
-        callback();
+        callback(null, this._transformChunk(chunk));
     }
 
     _flush(callback) {
@@ -60,11 +57,12 @@ class SAXParser extends Transform {
     }
 
     //Internals
-    _parseChunk(chunk) {
+    _transformChunk(chunk) {
         if (!this.stopped) {
             this.tokenizer.write(chunk.toString('utf8'), this.lastChunkWritten);
             this._runParsingLoop();
         }
+        return chunk;
     }
 
     _runParsingLoop() {

--- a/packages/parse5-sax-parser/lib/index.js
+++ b/packages/parse5-sax-parser/lib/index.js
@@ -43,10 +43,6 @@ class SAXParser extends Transform {
         callback(null, this._transformChunk(chunk));
     }
 
-    _flush(callback) {
-        callback();
-    }
-
     end(chunk, encoding, callback) {
         this.lastChunkWritten = true;
         super.end(chunk, encoding, callback);

--- a/packages/parse5-sax-parser/lib/index.js
+++ b/packages/parse5-sax-parser/lib/index.js
@@ -28,7 +28,6 @@ class SAXParser extends Transform {
         this.parserFeedbackSimulator = new ParserFeedbackSimulator(this.tokenizer);
 
         this.pendingText = null;
-        this.currentTokenLocation = void 0;
 
         this.lastChunkWritten = false;
         this.stopped = false;
@@ -112,10 +111,6 @@ class SAXParser extends Transform {
 
         const { eventName, reshapeToken } = TOKEN_EMISSION_HELPERS[token.type];
 
-        if (this.options.sourceCodeLocationInfo) {
-            this.currentTokenLocation = token.location;
-        }
-
         if (this.listenerCount(eventName) === 0) {
             return false;
         }
@@ -142,16 +137,16 @@ class SAXParser extends Transform {
             tagName: origToken.tagName,
             attrs: origToken.attrs,
             selfClosing: origToken.selfClosing,
-            sourceCodeLocation: this.currentTokenLocation
+            sourceCodeLocation: origToken.location
         };
     }
 
     _reshapeEndTagToken(origToken) {
-        return { tagName: origToken.tagName, sourceCodeLocation: this.currentTokenLocation };
+        return { tagName: origToken.tagName, sourceCodeLocation: origToken.location };
     }
 
     _reshapeCommentToken(origToken) {
-        return { text: origToken.data, sourceCodeLocation: this.currentTokenLocation };
+        return { text: origToken.data, sourceCodeLocation: origToken.location };
     }
 
     _reshapeDoctypeToken(origToken) {
@@ -159,12 +154,12 @@ class SAXParser extends Transform {
             name: origToken.name,
             publicId: origToken.publicId,
             systemId: origToken.systemId,
-            sourceCodeLocation: this.currentTokenLocation
+            sourceCodeLocation: origToken.location
         };
     }
 
     _reshapeCharToken(origToken) {
-        return { text: origToken.chars, sourceCodeLocation: this.currentTokenLocation };
+        return { text: origToken.chars, sourceCodeLocation: origToken.location };
     }
 }
 

--- a/packages/parse5-sax-parser/test/location-info.test.js
+++ b/packages/parse5-sax-parser/test/location-info.test.js
@@ -29,16 +29,20 @@ exports['Location info (SAX)'] = function() {
     });
 };
 
-exports['Regression - location info for text (GH-153)'] = function() {
+exports['Regression - location info for text (GH-153, GH-266)'] = function() {
     const html = '<!DOCTYPE html><html><head><title>Here is a title</title></html>';
     const parser = new SAXParser({ sourceCodeLocationInfo: true });
-    const texts = [];
 
     parser.on('text', ({ sourceCodeLocation }) => {
-        texts.push(html.substring(sourceCodeLocation.startOffset, sourceCodeLocation.endOffset));
+        assert.deepStrictEqual(sourceCodeLocation, {
+            startLine: 1,
+            startCol: 35,
+            startOffset: 34,
+            endLine: 1,
+            endCol: 50,
+            endOffset: 49
+        });
     });
 
     parser.end(html);
-
-    assert.deepEqual(texts, ['Here is a title']);
 };


### PR DESCRIPTION
 -  Fix `SAXParser` text end location (fixes #266).
 - Move lazy emission logic from `RewritingStream::_handleToken` to `SAXParser::_handleToken`. This allows `SAXParser` to skip reshaping when no listeners are registered and simplifies interaction between two APIs.
 - Make `SAXParser::pendingText` to keep a `CHARACTER` token instead of just chars. This aligns emission of pending text with other tokens and gives a single `_emitToken` point for `RewritingStream` to override (instead of additionally overriding `_emitPendingText` with similar logic).
 - Remove `SAXParser::currentTokenLocation` state, instead just retrieving location from current raw or processed token. It was needed mainly to track location for consequent text tokens, but since `pendingText` is now a token, it can store its own location internally. This additionally allows all `reshapeToken` helpers to become stateless and live outside of the class.