### PR TITLE
Accept only decoded string streams

### DIFF
--- a/bench/memory/sax-parser.js
+++ b/bench/memory/sax-parser.js
@@ -37,7 +37,7 @@ async function main() {
 }
 
 async function parse() {
-    const data = fs.readFileSync('../test/data/huge-page/huge-page.html');
+    const data = fs.readFileSync('../test/data/huge-page/huge-page.html', 'utf8');
     let parsedDataSize = 0;
     const stream = new SAXParser();
 

--- a/bench/perf/index.js
+++ b/bench/perf/index.js
@@ -107,7 +107,7 @@ runBench({
         const parsePromises = files.map(
             fileName =>
                 new Promise(resolve => {
-                    const stream = createReadStream(fileName);
+                    const stream = createReadStream(fileName, 'utf8');
                     const parserStream = new WorkingCopyParserStream();
 
                     stream.pipe(parserStream);
@@ -122,10 +122,10 @@ runBench({
         const parsePromises = files.map(
             fileName =>
                 new Promise(resolve => {
-                    const stream = createReadStream(fileName);
+                    const stream = createReadStream(fileName, 'utf8');
                     let data = '';
 
-                    stream.on('data', chunk => (data += chunk.toString('utf8')));
+                    stream.on('data', chunk => (data += chunk));
 
                     stream.on('end', () => {
                         upstreamParser.parse(data);

--- a/bench/perf/index.js
+++ b/bench/perf/index.js
@@ -5,7 +5,7 @@ const { readFileSync, createReadStream, readdirSync } = require('fs');
 const Benchmark = require('benchmark');
 const { loadTreeConstructionTestData } = require('../../test/utils/generate-parsing-tests');
 const loadSAXParserTestData = require('../../test/utils/load-sax-parser-test-data');
-const { treeAdapters } = require('../../test/utils/common');
+const { treeAdapters, WritableStreamStub } = require('../../test/utils/common');
 
 //HACK: https://github.com/bestiejs/benchmark.js/issues/51
 /* global workingCopy, WorkingCopyParserStream, upstreamParser, hugePage, microTests, runMicro, runPages, files */
@@ -123,14 +123,14 @@ runBench({
             fileName =>
                 new Promise(resolve => {
                     const stream = createReadStream(fileName, 'utf8');
-                    let data = '';
+                    const writable = new WritableStreamStub();
 
-                    stream.on('data', chunk => (data += chunk));
-
-                    stream.on('end', () => {
-                        upstreamParser.parse(data);
+                    writable.on('finish', () => {
+                        upstreamParser.parse(writable.writtenData);
                         resolve();
                     });
+
+                    stream.pipe(writable);
                 })
         );
 

--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.js
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.js
@@ -263,3 +263,10 @@ exports['Regression - RewritingStream - Last text chunk must be flushed (GH-271)
     parser.write('text');
     parser.end();
 };
+
+exports['Regression - RewritingStream - Should not accept binary input (GH-269)'] = () => {
+    const stream = new RewritingStream();
+    const buf = Buffer.from('test');
+
+    assert.throws(() => stream.write(buf), TypeError);
+};

--- a/packages/parse5-parser-stream/lib/index.js
+++ b/packages/parse5-parser-stream/lib/index.js
@@ -5,7 +5,7 @@ const Parser = require('parse5/lib/parser');
 
 class ParserStream extends Writable {
     constructor(options) {
-        super();
+        super({ decodeStrings: false });
 
         this.parser = new Parser(options);
 
@@ -26,8 +26,12 @@ class ParserStream extends Writable {
 
     //WritableStream implementation
     _write(chunk, encoding, callback) {
+        if (typeof chunk !== 'string') {
+            throw new TypeError('Parser can work only with string streams.');
+        }
+
         this.writeCallback = callback;
-        this.parser.tokenizer.write(chunk.toString('utf8'), this.lastChunkWritten);
+        this.parser.tokenizer.write(chunk, this.lastChunkWritten);
         this._runParsingLoop();
     }
 

--- a/packages/parse5-parser-stream/test/parser-stream.test.js
+++ b/packages/parse5-parser-stream/test/parser-stream.test.js
@@ -13,3 +13,10 @@ exports['Regression - Fix empty stream parsing with ParserStream (GH-196)'] = fu
 
     parser.end();
 };
+
+exports['Regression - ParserStream - Should not accept binary input (GH-269)'] = () => {
+    const stream = new ParserStream();
+    const buf = Buffer.from('test');
+
+    assert.throws(() => stream.write(buf), TypeError);
+};

--- a/packages/parse5-parser-stream/test/utils/parse-chunked.js
+++ b/packages/parse5-parser-stream/test/utils/parse-chunked.js
@@ -9,6 +9,9 @@ module.exports = function parseChunked(html, opts, minChunkSize, maxChunkSize) {
     parserStream.parser.tokenizer.preprocessor.bufferWaterline = 8;
 
     for (let i = 0; i < chunks.length - 1; i++) {
+        if (typeof chunks[i] !== 'string') {
+            throw new TypeError();
+        }
         parserStream.write(chunks[i]);
     }
 

--- a/packages/parse5-plain-text-conversion-stream/test/plain-text-conversion-stream.test.js
+++ b/packages/parse5-plain-text-conversion-stream/test/plain-text-conversion-stream.test.js
@@ -22,3 +22,10 @@ generateTestsForEachTreeAdapter(module.exports, (_test, treeAdapter) => {
         );
     };
 });
+
+exports['Regression - Plain text conversion stream - Should not accept binary input (GH-269)'] = () => {
+    const stream = new PlainTextConversionStream();
+    const buf = Buffer.from('test');
+
+    assert.throws(() => stream.write(buf), TypeError);
+};

--- a/packages/parse5-sax-parser/lib/index.js
+++ b/packages/parse5-sax-parser/lib/index.js
@@ -14,7 +14,7 @@ const DEFAULT_OPTIONS = {
 
 class SAXParser extends Transform {
     constructor(options) {
-        super();
+        super({ encoding: 'utf8', decodeStrings: false });
 
         this.options = mergeOptions(DEFAULT_OPTIONS, options);
 
@@ -40,6 +40,10 @@ class SAXParser extends Transform {
 
     //TransformStream implementation
     _transform(chunk, encoding, callback) {
+        if (typeof chunk !== 'string') {
+            throw new TypeError('Parser can work only with string streams.');
+        }
+
         callback(null, this._transformChunk(chunk));
     }
 
@@ -55,7 +59,7 @@ class SAXParser extends Transform {
     //Internals
     _transformChunk(chunk) {
         if (!this.stopped) {
-            this.tokenizer.write(chunk.toString('utf8'), this.lastChunkWritten);
+            this.tokenizer.write(chunk, this.lastChunkWritten);
             this._runParsingLoop();
         }
         return chunk;

--- a/packages/parse5-sax-parser/test/sax-parser.test.js
+++ b/packages/parse5-sax-parser/test/sax-parser.test.js
@@ -142,3 +142,10 @@ exports['Regression - SAX - Last text chunk must be flushed (GH-271)'] = done =>
     parser.write('text');
     parser.end();
 };
+
+exports['Regression - SAX - Should not accept binary input (GH-269)'] = () => {
+    const stream = new SAXParser();
+    const buf = Buffer.from('test');
+
+    assert.throws(() => stream.write(buf), TypeError);
+};

--- a/packages/parse5-sax-parser/test/sax-parser.test.js
+++ b/packages/parse5-sax-parser/test/sax-parser.test.js
@@ -95,7 +95,7 @@ exports['SAX - Piping and .stop()'] = function(done) {
         }
     };
 
-    fs.createReadStream(path.join(__dirname, '../../../test/data/huge-page/huge-page.html'))
+    fs.createReadStream(path.join(__dirname, '../../../test/data/huge-page/huge-page.html'), 'utf8')
         .pipe(parser)
         .pipe(writable);
 
@@ -119,7 +119,7 @@ exports['SAX - Piping and .stop()'] = function(done) {
 exports['Regression - SAX - Parser silently exits on big files (GH-97)'] = function(done) {
     const parser = new SAXParser();
 
-    fs.createReadStream(path.join(__dirname, '../../../test/data/huge-page/huge-page.html')).pipe(parser);
+    fs.createReadStream(path.join(__dirname, '../../../test/data/huge-page/huge-page.html'), 'utf8').pipe(parser);
 
     //NOTE: This is a smoke test - in case of regression it will fail with timeout.
     parser.once('finish', done);

--- a/packages/parse5-serializer-stream/lib/index.js
+++ b/packages/parse5-serializer-stream/lib/index.js
@@ -5,7 +5,7 @@ const Serializer = require('parse5/lib/serializer');
 
 class SerializerStream extends Readable {
     constructor(node, options) {
-        super();
+        super({ encoding: 'utf8' });
 
         this.serializer = new Serializer(node, options);
 

--- a/packages/parse5-serializer-stream/test/serializer-stream.test.js
+++ b/packages/parse5-serializer-stream/test/serializer-stream.test.js
@@ -1,24 +1,16 @@
 'use strict';
 
-const { Writable } = require('stream');
 const SerializerStream = require('../lib');
 const generateSeriliazerTests = require('../../../test/utils/generate-serializer-tests');
+const { WritableStreamStub } = require('../../../test/utils/common');
 
 generateSeriliazerTests(exports, 'SeriliazerStream', (document, opts) => {
     const stream = new SerializerStream(document, opts);
-    const writable = new Writable();
-    let result = '';
-
-    //NOTE: use pipe to the WritableStream to test stream
-    //in the `flowing` mode.
-    writable._write = (chunk, encoding, callback) => {
-        result += chunk.toString();
-        callback();
-    };
+    const writable = new WritableStreamStub();
 
     stream.pipe(writable);
 
     return new Promise(resolve => {
-        writable.once('finish', () => resolve(result));
+        writable.once('finish', () => resolve(writable.writtenData));
     });
 });

--- a/test/utils/common.js
+++ b/test/utils/common.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Writable } = require('stream');
+const assert = require('assert');
 
 const treeAdapters = {
     default: require('../../packages/parse5/lib/tree-adapters/default'),
@@ -58,12 +59,13 @@ function makeChunks(str, minSize, maxSize) {
 
 class WritableStreamStub extends Writable {
     constructor() {
-        super();
+        super({ decodeStrings: false });
 
         this.writtenData = '';
     }
 
     _write(chunk, encoding, callback) {
+        assert.strictEqual(typeof chunk, 'string', 'Expected output to be a string stream');
         this.writtenData += chunk;
         callback();
     }


### PR DESCRIPTION
Previously, all streams accepted buffer chunks, decoding each one individually into a string as UTF-8.

This is problematic due to several reasons:
 1. It's not guaranteed that a binary stream is indeed UTF-8, and parse5 doesn't currently implement encoding detection to properly recognise anything else.
 2. For any multibyte encoding, including UTF-8, it's not guaranteed that a binary chunk on its own is a valid text as a codepoint can be split between different chunks (this was not caught by tests because they already feed string chunks into the parser).
 3. Writable parts of the stream didn't have `decodeString: false`, which means that by default Node.js would unnecessarily "decode" (d'oh, that naming is confusing) any string into a Buffer, feed it into a parser stream, and it would decode that Buffer back to a string. This is wasteful.

This commit fixes these issues by adding `decodeString: false` to Writable constructors so that string are passed into `_write` and `_transform` implementations as-is, and adds assertions to make sure that input is indeed a string.

Technically this is a breaking change as now all consumers are expected to feed readable stream with correct encoding (this is easy to do by passing `encoding: "utf8"` to any standard readable stream), and not just binary chunks, so parse5 will start throwing for existing binary usages, but I believe this is better than silently accepting and potentially breaking raw input.

Another option to accept raw input would be to use `StringDecoder` internally, but this would bring us back to issue (1) in the list, as we would need to properly detect input encoding rather than just assume it's UTF-8, so I'd rather leave this as a future enhancement.

Fixes #269.