### PR TITLE
SAX: Always flush the last chunk

### DIFF
--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.js
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.js
@@ -245,3 +245,21 @@ exports['RewritingStream - Should escape entities in attributes and text'] = cre
         rewriter.on('text', token => rewriter.emitText(token));
     }
 });
+
+exports['Regression - RewritingStream - Last text chunk must be flushed (GH-271)'] = done => {
+    const parser = new RewritingStream();
+    let foundText = false;
+
+    parser.on('text', ({ text }) => {
+        foundText = true;
+        assert.strictEqual(text, 'text');
+    });
+
+    parser.once('finish', () => {
+        assert.ok(foundText);
+        done();
+    });
+
+    parser.write('text');
+    parser.end();
+};

--- a/packages/parse5-sax-parser/lib/index.js
+++ b/packages/parse5-sax-parser/lib/index.js
@@ -43,9 +43,9 @@ class SAXParser extends Transform {
         callback(null, this._transformChunk(chunk));
     }
 
-    end(chunk, encoding, callback) {
+    _final(callback) {
         this.lastChunkWritten = true;
-        super.end(chunk, encoding, callback);
+        callback(null, this._transformChunk(''));
     }
 
     stop() {

--- a/packages/parse5-sax-parser/test/sax-parser.test.js
+++ b/packages/parse5-sax-parser/test/sax-parser.test.js
@@ -116,11 +116,29 @@ exports['SAX - Piping and .stop()'] = function(done) {
     });
 };
 
-exports['Regression-SAX-SAX parser silently exits on big files (GH-97)'] = function(done) {
+exports['Regression - SAX - Parser silently exits on big files (GH-97)'] = function(done) {
     const parser = new SAXParser();
 
     fs.createReadStream(path.join(__dirname, '../../../test/data/huge-page/huge-page.html')).pipe(parser);
 
     //NOTE: This is a smoke test - in case of regression it will fail with timeout.
     parser.once('finish', done);
+};
+
+exports['Regression - SAX - Last text chunk must be flushed (GH-271)'] = done => {
+    const parser = new SAXParser();
+    let foundText = false;
+
+    parser.on('text', ({ text }) => {
+        foundText = true;
+        assert.strictEqual(text, 'text');
+    });
+
+    parser.once('finish', () => {
+        assert.ok(foundText);
+        done();
+    });
+
+    parser.write('text');
+    parser.end();
 };


### PR DESCRIPTION
The last chunk wasn't flushed when `.end()` on the stream is called without its own chunk, as in that case it doesn't invoke `_transform`.

Fixes #271.