### PR TITLE
allow serialize callers to provide optional string escape callback

### DIFF
--- a/packages/parse5/docs/options/serializer-options.md
+++ b/packages/parse5/docs/options/serializer-options.md
@@ -8,6 +8,17 @@
 
 ## Properties
 
+<a id="escapeString"></a>
+
+### `<Optional>` escapeString
+
+**● escapeString**: *function(str, attrMode)*
+
+Callback for custom escaping behavior. Should return the desired version of `str`,
+considering `attrMode` indicating whether the string occurred inside an attribute.
+
+**Default:** `Serializer.escapeString`
+
 <a id="treeadapter"></a>
 
 ### `<Optional>` treeAdapter

--- a/packages/parse5/lib/serializer/index.js
+++ b/packages/parse5/lib/serializer/index.js
@@ -100,7 +100,7 @@ class Serializer {
 
         for (let i = 0, attrsLength = attrs.length; i < attrsLength; i++) {
             const attr = attrs[i];
-            const value = Serializer.escapeString(attr.value, true);
+            const value = this.options.escapeString(attr.value, true);
 
             this.html += ' ';
 
@@ -145,7 +145,7 @@ class Serializer {
         ) {
             this.html += content;
         } else {
-            this.html += Serializer.escapeString(content, false);
+            this.html += this.options.escapeString(content, false);
         }
     }
 
@@ -161,7 +161,7 @@ class Serializer {
 }
 
 // NOTE: used in tests and by rewriting stream
-Serializer.escapeString = function(str, attrMode) {
+Serializer.escapeString = DEFAULT_OPTIONS.escapeString = function(str, attrMode) {
     str = str.replace(AMP_REGEX, '&amp;').replace(NBSP_REGEX, '&nbsp;');
 
     if (attrMode) {


### PR DESCRIPTION
I ran into [a situation](https://github.com/PolymerX/lit-loader/pull/5) where this library was used to reassemble a document, but it was a document including some template syntax that needs not to be converted to HTML entities (`>` => `&gt;`).

Granted the result is not valid HTML5 and thus arguably out of scope here, but the option to provide a custom escaping strategy might have some further use to customize handling of higher UTF chars or something.