### PR TITLE
Fix docs for Location info: endOffset & endCol

### DIFF
--- a/packages/parse5/docs/source-code-location/element-location.md
+++ b/packages/parse5/docs/source-code-location/element-location.md
@@ -31,7 +31,7 @@ ___
 
 **● endCol**: *`number`*
 
-One-based column index of the last character
+One-based column index plus 1 of the last character, ie. it points *after* the last character
 
 ___
 <a id="endoffset"></a>
@@ -40,7 +40,7 @@ ___
 
 **● endOffset**: *`number`*
 
-Zero-based last character index
+Zero-based last character index plus 1, ie. it points *after* the last character
 
 ___
 <a id="endline"></a>

--- a/packages/parse5/docs/source-code-location/element-location.md
+++ b/packages/parse5/docs/source-code-location/element-location.md
@@ -31,7 +31,7 @@ ___
 
 **● endCol**: *`number`*
 
-One-based column index plus 1 of the last character, ie. it points *after* the last character
+One-based column index *plus 1* of the last character, ie. it points *after* the last character
 
 ___
 <a id="endoffset"></a>
@@ -40,7 +40,7 @@ ___
 
 **● endOffset**: *`number`*
 
-Zero-based last character index plus 1, ie. it points *after* the last character
+Zero-based last character index *plus 1*, ie. it points *after* the last character
 
 ___
 <a id="endline"></a>

--- a/packages/parse5/docs/source-code-location/location.md
+++ b/packages/parse5/docs/source-code-location/location.md
@@ -19,7 +19,7 @@
 
 **● endCol**: *`number`*
 
-One-based column index of the last character
+One-based column index plus 1 of the last character, ie. it points *after* the last character
 
 ___
 <a id="endoffset"></a>
@@ -28,7 +28,7 @@ ___
 
 **● endOffset**: *`number`*
 
-Zero-based last character index
+Zero-based last character index plus 1, ie. it points *after* the last character
 
 ___
 <a id="endline"></a>

--- a/packages/parse5/docs/source-code-location/location.md
+++ b/packages/parse5/docs/source-code-location/location.md
@@ -19,7 +19,7 @@
 
 **● endCol**: *`number`*
 
-One-based column index plus 1 of the last character, ie. it points *after* the last character
+One-based column index *plus 1* of the last character, ie. it points *after* the last character
 
 ___
 <a id="endoffset"></a>
@@ -28,7 +28,7 @@ ___
 
 **● endOffset**: *`number`*
 
-Zero-based last character index plus 1, ie. it points *after* the last character
+Zero-based last character index *plus 1*, ie. it points *after* the last character
 
 ___
 <a id="endline"></a>

--- a/packages/parse5/docs/source-code-location/start-tag-location.md
+++ b/packages/parse5/docs/source-code-location/start-tag-location.md
@@ -29,7 +29,7 @@ ___
 
 **● endCol**: *`number`*
 
-One-based column index plus 1 of the last character, ie. it points *after* the last character
+One-based column index *plus 1* of the last character, ie. it points *after* the last character
 
 ___
 <a id="endoffset"></a>
@@ -38,7 +38,7 @@ ___
 
 **● endOffset**: *`number`*
 
-Zero-based last character index plus 1, ie. it points *after* the last character
+Zero-based last character index *plus 1*, ie. it points *after* the last character
 
 ___
 <a id="endline"></a>

--- a/packages/parse5/docs/source-code-location/start-tag-location.md
+++ b/packages/parse5/docs/source-code-location/start-tag-location.md
@@ -29,7 +29,7 @@ ___
 
 **● endCol**: *`number`*
 
-One-based column index of the last character
+One-based column index plus 1 of the last character, ie. it points *after* the last character
 
 ___
 <a id="endoffset"></a>
@@ -38,7 +38,7 @@ ___
 
 **● endOffset**: *`number`*
 
-Zero-based last character index
+Zero-based last character index plus 1, ie. it points *after* the last character
 
 ___
 <a id="endline"></a>


### PR DESCRIPTION
In the files under https://github.com/inikulin/parse5/tree/master/packages/parse5/docs/source-code-location it says:
* `endOffset`: Zero-based index of the last character
* `endCol`: One-based column index of the last character

That's incorrect: they do not point *at* the last character but *after* the last character (which is as it should be, like String.substring or String.slice).

Note that `endLine` is described correctly as "One-based line index of the last character".
That is, this (one-based) index really points *at* the line that contains the last character.
Again, that's how it should be. However, maybe add a note to this effect - like the above - to the docs?

For now, I've just added "plus 1" and ", ie. it points *after* the last character" for `endOffset` and `endCol`.

I'll happily amend this PR in case of any suggestion for better and/or additional formulations.