### PR TITLE
Fix serialization of attributes in non-standard namespaces

### DIFF
--- a/packages/parse5/lib/serializer/index.js
+++ b/packages/parse5/lib/serializer/index.js
@@ -117,7 +117,7 @@ class Serializer {
             } else if (attr.namespace === NS.XLINK) {
                 this.html += 'xlink:' + attr.name;
             } else {
-                this.html += attr.namespace + ':' + attr.name;
+                this.html += attr.prefix + ':' + attr.name;
             }
 
             this.html += '="' + value + '"';


### PR DESCRIPTION
I came across this issue in the test case ["Attribute in non-standard namespace"](https://github.com/web-platform-tests/wpt/blob/master/html/syntax/serializing-html-fragments/serializing.html#L118) while I was debugging jsdom.

This serializes them as `prefix:localName` - the [qualified name](https://dom.spec.whatwg.org/#concept-element-qualified-name) - rather than `namespace:localName`, according to the specification at https://html.spec.whatwg.org/multipage/parsing.html#attribute's-serialised-name.

This should probably include a test case, but it's not immediately clear to me how to test using an unknown namespace within the existing structure.