### PR TITLE
Fix null value passed to escapeString caused error

### DIFF
--- a/packages/parse5/lib/serializer/index.js
+++ b/packages/parse5/lib/serializer/index.js
@@ -162,6 +162,9 @@ class Serializer {
 
 // NOTE: used in tests and by rewriting stream
 Serializer.escapeString = function(str, attrMode) {
+    if (str === null) {
+        str = '';
+    }
     str = str.replace(AMP_REGEX, '&amp;').replace(NBSP_REGEX, '&nbsp;');
 
     if (attrMode) {

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -1,7 +1,7 @@
 {
     "name": "parse5",
     "description": "HTML parser and serializer.",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://github.com/inikulin/parse5",


### PR DESCRIPTION
Issue:
If null value passed to escapeString  function then replace function would fail.

Solution:
Fix this so that framework doesn't break.