### PR TITLE
Add updateNodeSourceCodeLocation to the tree adapter

### DIFF
--- a/packages/parse5-htmlparser2-tree-adapter/lib/index.js
+++ b/packages/parse5-htmlparser2-tree-adapter/lib/index.js
@@ -343,6 +343,6 @@ exports.getNodeSourceCodeLocation = function(node) {
     return node.sourceCodeLocation;
 };
 
-exports.updateNodeSourceCodeLocation = function(node, location) {
-    node.sourceCodeLocation = Object.assign(node.sourceCodeLocation, location);
+exports.updateNodeSourceCodeLocation = function(node, endLocation) {
+    node.sourceCodeLocation = Object.assign(node.sourceCodeLocation, endLocation);
 };

--- a/packages/parse5-htmlparser2-tree-adapter/lib/index.js
+++ b/packages/parse5-htmlparser2-tree-adapter/lib/index.js
@@ -342,3 +342,7 @@ exports.setNodeSourceCodeLocation = function(node, location) {
 exports.getNodeSourceCodeLocation = function(node) {
     return node.sourceCodeLocation;
 };
+
+exports.updateNodeSourceCodeLocation = function(node, location) {
+    node.sourceCodeLocation = Object.assign(node.sourceCodeLocation, location);
+};

--- a/packages/parse5/docs/source-code-location/end-location.md
+++ b/packages/parse5/docs/source-code-location/end-location.md
@@ -1,0 +1,48 @@
+# Interface: EndLocation
+
+### Properties
+
+* [endCol](#endcol)
+* [endOffset](#endoffset)
+* [endLine](#endline)
+* [endTag](#endtag)
+
+---
+
+## Properties
+
+<a id="endcol"></a>
+
+###  endCol
+
+**● endCol**: *`number`*
+
+One-based column index of the last character
+
+___
+<a id="endoffset"></a>
+
+###  endOffset
+
+**● endOffset**: *`number`*
+
+Zero-based last character index
+
+___
+<a id="endline"></a>
+
+###  endLine
+
+**● endLine**: *`number`*
+
+One-based line index of the last character
+
+___
+<a id="endtag"></a>
+
+###  endTag
+
+**● endTag**: *[Location](location.md)|undefined*
+
+Element's end tag location info.
+This property is undefined, if the element has no closing tag.

--- a/packages/parse5/docs/tree-adapter/interface.md
+++ b/packages/parse5/docs/tree-adapter/interface.md
@@ -595,14 +595,14 @@ ___
 
 ▸ **updateNodeSourceCodeLocation**(node: *Node*, endLocation: *[EndLocation](../source-code-location/end-location.md)*): `void`
 
-Updates the source code location of element nodes.
+Updates the source code location of nodes.
 
 **Parameters:**
 
 | Param | Type | Description |
 | ------ | ------ | ------ |
 | node | Node |  Node. |
-| endLocation | [EndLocation](../source-code-location/end-location.md) |  Source code location information of the end of the element. |
+| endLocation | [EndLocation](../source-code-location/end-location.md) |  Source code location information of the end of the node. |
 
 **Returns:** `void`
 ___

--- a/packages/parse5/docs/tree-adapter/interface.md
+++ b/packages/parse5/docs/tree-adapter/interface.md
@@ -38,7 +38,7 @@ Tree adapter is a set of utility functions that provides minimal required abstra
 * [setDocumentType](#setdocumenttype)
 * [setNodeSourceCodeLocation](#setnodesourcecodelocation)
 * [setTemplateContent](#settemplatecontent)
-
+* [updateNodeSourceCodeLocation](#updatenodesourcecodelocation)
 ---
 
 ## Methods
@@ -588,6 +588,21 @@ Sets the `<template>` element content element.
 | contentElement | DocumentFragment |  Content element. |
 
 **Returns:** `void`
-
 ___
+<a id="updatenodesourcecodelocation"></a>
 
+###  updateNodeSourceCodeLocation
+
+▸ **updateNodeSourceCodeLocation**(node: *Node*, location: *[EndLocation](../source-code-location/end-location.md)*): `void`
+
+Updates the source code location of element nodes.
+
+**Parameters:**
+
+| Param | Type | Description |
+| ------ | ------ | ------ |
+| node | Node |  Node. |
+| location | [EndLocation](../source-code-location/end-location.md) |  Source code location information of the end of the element. |
+
+**Returns:** `void`
+___

--- a/packages/parse5/docs/tree-adapter/interface.md
+++ b/packages/parse5/docs/tree-adapter/interface.md
@@ -593,7 +593,7 @@ ___
 
 ###  updateNodeSourceCodeLocation
 
-▸ **updateNodeSourceCodeLocation**(node: *Node*, location: *[EndLocation](../source-code-location/end-location.md)*): `void`
+▸ **updateNodeSourceCodeLocation**(node: *Node*, endLocation: *[EndLocation](../source-code-location/end-location.md)*): `void`
 
 Updates the source code location of element nodes.
 
@@ -602,7 +602,7 @@ Updates the source code location of element nodes.
 | Param | Type | Description |
 | ------ | ------ | ------ |
 | node | Node |  Node. |
-| location | [EndLocation](../source-code-location/end-location.md) |  Source code location information of the end of the element. |
+| endLocation | [EndLocation](../source-code-location/end-location.md) |  Source code location information of the end of the element. |
 
 **Returns:** `void`
 ___

--- a/packages/parse5/lib/extensions/location-info/parser-mixin.js
+++ b/packages/parse5/lib/extensions/location-info/parser-mixin.js
@@ -210,9 +210,8 @@ class LocationInfoParserMixin extends Mixin {
                 const tnLoc = this.treeAdapter.getNodeSourceCodeLocation(textNode);
 
                 if (tnLoc) {
-                    tnLoc.endLine = token.location.endLine;
-                    tnLoc.endCol = token.location.endCol;
-                    tnLoc.endOffset = token.location.endOffset;
+                    const { endLine, endCol, endOffset } = token.location;
+                    this.treeAdapter.updateNodeSourceCodeLocation(textNode, { endLine, endCol, endOffset });
                 } else {
                     this.treeAdapter.setNodeSourceCodeLocation(textNode, token.location);
                 }

--- a/packages/parse5/lib/extensions/location-info/parser-mixin.js
+++ b/packages/parse5/lib/extensions/location-info/parser-mixin.js
@@ -43,17 +43,19 @@ class LocationInfoParserMixin extends Mixin {
                 // NOTE: For cases like <p> <p> </p> - First 'p' closes without a closing
                 // tag and for cases like <td> <p> </td> - 'p' closes without a closing tag.
                 const isClosingEndTag = closingToken.type === Tokenizer.END_TAG_TOKEN && tn === closingToken.tagName;
-
+                const endLoc = {};
                 if (isClosingEndTag) {
-                    loc.endTag = Object.assign({}, ctLoc);
-                    loc.endLine = ctLoc.endLine;
-                    loc.endCol = ctLoc.endCol;
-                    loc.endOffset = ctLoc.endOffset;
+                    endLoc.endTag = Object.assign({}, ctLoc);
+                    endLoc.endLine = ctLoc.endLine;
+                    endLoc.endCol = ctLoc.endCol;
+                    endLoc.endOffset = ctLoc.endOffset;
                 } else {
-                    loc.endLine = ctLoc.startLine;
-                    loc.endCol = ctLoc.startCol;
-                    loc.endOffset = ctLoc.startOffset;
+                    endLoc.endLine = ctLoc.startLine;
+                    endLoc.endCol = ctLoc.startCol;
+                    endLoc.endOffset = ctLoc.startOffset;
                 }
+
+                this.treeAdapter.updateNodeSourceCodeLocation(element, endLoc);
             }
         }
     }

--- a/packages/parse5/lib/tree-adapters/default.js
+++ b/packages/parse5/lib/tree-adapters/default.js
@@ -216,6 +216,6 @@ exports.getNodeSourceCodeLocation = function(node) {
     return node.sourceCodeLocation;
 };
 
-exports.updateNodeSourceCodeLocation = function(node, location) {
-    node.sourceCodeLocation = Object.assign(node.sourceCodeLocation, location);
+exports.updateNodeSourceCodeLocation = function(node, endLocation) {
+    node.sourceCodeLocation = Object.assign(node.sourceCodeLocation, endLocation);
 };

--- a/packages/parse5/lib/tree-adapters/default.js
+++ b/packages/parse5/lib/tree-adapters/default.js
@@ -215,3 +215,7 @@ exports.setNodeSourceCodeLocation = function(node, location) {
 exports.getNodeSourceCodeLocation = function(node) {
     return node.sourceCodeLocation;
 };
+
+exports.updateNodeSourceCodeLocation = function(node, location) {
+    node.sourceCodeLocation = Object.assign(node.sourceCodeLocation, location);
+};


### PR DESCRIPTION
Hi,
I added the `updateNodeSourceCodeLocation` as discussed in #314 .
Code:
I decided to only pass the updated node location and not the whole location.

Tests:
I did not find test code specific to the default or htmlparser2 tree adapter.
All current tests (via npm run unit-tests) pass.

Documentation:
I added the function description to the tree adapter documentation and created a new end-location.md by copy&pasting the information from the other location documentation.

