### PR TITLE
set hr tags as self closing

### DIFF
--- a/packages/parse5/lib/parser/index.js
+++ b/packages/parse5/lib/parser/index.js
@@ -1546,7 +1546,7 @@ function hrStartTagInBody(p, token) {
 
     p._appendElement(token, NS.HTML);
     p.framesetOk = false;
-    p.ackSelfClosing = true;
+    token.ackSelfClosing = true;
 }
 
 function imageStartTagInBody(p, token) {


### PR DESCRIPTION
as far as i can see, this is a typo.

it is currently causing failures in our linter (which depends on parse5) when parsing HR tags.

your tests are a little non-self-explanatory so if there's somewhere i can add one, please do let me know.