### PR TITLE
Make << in comment text parse correctly

### DIFF
--- a/packages/parse5/lib/tokenizer/index.js
+++ b/packages/parse5/lib/tokenizer/index.js
@@ -1468,7 +1468,7 @@ class Tokenizer {
             this.currentToken.data += '!';
             this.state = COMMENT_LESS_THAN_SIGN_BANG_STATE;
         } else if (cp === $.LESS_THAN_SIGN) {
-            this.currentToken.data += '!';
+            this.currentToken.data += '<';
         } else {
             this._reconsumeInState(COMMENT_STATE);
         }

--- a/packages/parse5/test/tokenizer.test.js
+++ b/packages/parse5/test/tokenizer.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assert = require('assert');
+const parse5 = require('../lib');
 const path = require('path');
 const Tokenizer = require('../lib/tokenizer');
 const Mixin = require('../lib/utils/mixin');
@@ -26,3 +28,10 @@ generateTokenizationTests(
         return { tokenizer, getNextToken: () => tokenizer.getNextToken() };
     }
 );
+
+exports['Regression - `<<` in comment parses correctly (GH-325)'] = {
+    test() {
+        const document = parse5.parse('<!--<<-->');
+        assert.equal(document.childNodes[0].data, '<<');
+    }
+};


### PR DESCRIPTION
Inside comments two consecutive less-than characters (`<<`) parsed wrongly as `<!`, due to what was probably a typo.  This fixes that.

Also added regression test.

Fixes #325.