### PR TITLE
Do not escape ampersand (`&`) in href attribute

### DIFF
--- a/packages/parse5-html-rewriting-stream/lib/index.js
+++ b/packages/parse5-html-rewriting-stream/lib/index.js
@@ -64,7 +64,7 @@ class RewritingStream extends SAXParser {
         const attrs = token.attrs;
 
         for (let i = 0; i < attrs.length; i++) {
-            res += ` ${attrs[i].name}="${escapeString(attrs[i].value, true)}"`;
+            res += ` ${attrs[i].name}="${escapeString(attrs[i].value, true, attrs[i].name === 'href')}"`;
         }
 
         res += token.selfClosing ? '/>' : '>';

--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.js
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.js
@@ -246,6 +246,33 @@ exports['RewritingStream - Should escape entities in attributes and text'] = cre
     }
 });
 
+exports['Regression - RewritingStream - Should not escape ampersand in URLs'] = createRewriterTest({
+    src: dedent`
+        <!DOCTYPE html "">
+        <html>
+            <head>
+                <link href="https://foo.com?bar=0&bla=1">
+            </head>
+            <body>
+            </body>
+        </html>
+    `,
+    expected: dedent`
+        <!DOCTYPE html "">
+        <html>
+            <head>
+                <link href="https://foo.com?bar=0&bla=1">
+            </head>
+            <body>
+            </body>
+        </html>
+    `,
+    assignTokenHandlers: rewriter => {
+        rewriter.on('startTag', token => rewriter.emitStartTag(token));
+        rewriter.on('text', token => rewriter.emitText(token));
+    }
+});
+
 exports['Regression - RewritingStream - Last text chunk must be flushed (GH-271)'] = done => {
     const parser = new RewritingStream();
     let foundText = false;

--- a/packages/parse5/lib/serializer/index.js
+++ b/packages/parse5/lib/serializer/index.js
@@ -161,8 +161,12 @@ class Serializer {
 }
 
 // NOTE: used in tests and by rewriting stream
-Serializer.escapeString = function(str, attrMode) {
-    str = str.replace(AMP_REGEX, '&amp;').replace(NBSP_REGEX, '&nbsp;');
+Serializer.escapeString = function(str, attrMode, urlMode) {
+    if (!urlMode) {
+        str = str.replace(AMP_REGEX, '&amp;');
+    }
+
+    str = str.replace(NBSP_REGEX, '&nbsp;');
 
     if (attrMode) {
         str = str.replace(DOUBLE_QUOTE_REGEX, '&quot;');


### PR DESCRIPTION
Prior to this commit an ampersand would be escaped although it is
totally valid. This commit fixes that.