### PR TITLE
chore(ci): Switch to GitHub Actions CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: '/'
+      schedule:
+          interval: daily
+      open-pull-requests-limit: 10
+      versioning-strategy: increase
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: daily
+    - package-ecosystem: gitsubmodule
+      directory: '/'
+      schedule:
+          interval: daily

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,33 @@
+name: 'CodeQL'
+
+on:
+    push:
+        branches: [master]
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: [master]
+    schedule:
+        - cron: '0 0 * * 0'
+
+jobs:
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+              with:
+                  submodules: recursive
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v1
+              with:
+                  languages: 'javascript'
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+# Based on https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+name: Dependabot auto-merge
+on: pull_request_target
+
+permissions:
+    pull-requests: write
+    contents: write
+
+jobs:
+    dependabot:
+        runs-on: ubuntu-latest
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        steps:
+            - name: Dependabot metadata
+              id: metadata
+              uses: dependabot/fetch-metadata@v1.1.1
+              with:
+                  github-token: '${{ secrets.GITHUB_TOKEN }}'
+            - name: Enable auto-merge for Dependabot PRs
+              # Automatically merge semver-patch and semver-minor PRs
+              if: "${{ steps.metadata.outputs.update-type ==
+                  'version-update:semver-minor' ||
+                  steps.metadata.outputs.update-type ==
+                  'version-update:semver-patch' }}"
+              run: gh pr merge --auto --squash "$PR_URL"
+              env:
+                  PR_URL: ${{github.event.pull_request.html_url}}
+                  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -1,0 +1,54 @@
+name: Node.js CI
+
+on:
+    push:
+        branches-ignore:
+            - 'dependabot/**'
+    pull_request:
+
+env:
+    CI: true
+    FORCE_COLOR: 2
+
+jobs:
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: recursive
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: lts/*
+                  cache: npm
+            - run: npm ci
+            - run: npm run lint
+
+    test:
+        name: Node ${{ matrix.node }}
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                node:
+                    - 12
+                    - 14
+                    - 16
+                    - lts/*
+
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: recursive
+            - name: Use Node.js ${{ matrix.node }}
+              uses: actions/setup-node@v2
+              with:
+                  node-version: ${{ matrix.node }}
+                  cache: npm
+            - run: npm install -g npm@8
+            - run: npm ci
+            - run: npm run build --if-present
+
+            - name: Run Tests
+              run: npm run unit-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-sudo: false
-node_js:
-  - stable


### PR DESCRIPTION
Also introduces Dependabot.

Travis.org is no longer supported, and the choice would have been to either switch to their .com offering, or switch CI providers entirely. GitHub Actions is the first party solution here, so let's use that!