### PR TITLE
Refactor & improve serializer

### DIFF
--- a/packages/parse5-serializer-stream/lib/index.ts
+++ b/packages/parse5-serializer-stream/lib/index.ts
@@ -34,20 +34,11 @@ export class SerializerStream<T extends TreeAdapterTypeMap> extends Readable {
         super({ encoding: 'utf8' });
 
         this.serializer = new Serializer(node, options);
-
-        Object.defineProperty(this.serializer, 'html', {
-            //NOTE: To make `+=` concat operator work properly we define
-            //getter which always returns empty string
-            get() {
-                return '';
-            },
-            set: (data: string) => this.push(data),
-        });
     }
 
     //Readable stream implementation
     override _read(): void {
-        this.serializer.serialize();
+        this.push(this.serializer.serialize());
         this.push(null);
     }
 }

--- a/packages/parse5-serializer-stream/lib/index.ts
+++ b/packages/parse5-serializer-stream/lib/index.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'node:stream';
-import { Serializer, SerializerOptions } from 'parse5/dist/serializer/index.js';
+import { serializeChildNodes, SerializerOptions } from 'parse5/dist/serializer/index.js';
 import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
 
 /**
@@ -22,23 +22,19 @@ import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js'
  * ```
  */
 export class SerializerStream<T extends TreeAdapterTypeMap> extends Readable {
-    private serializer: Serializer<T>;
-
     /**
      * Streaming AST node to an HTML serializer. A readable stream.
      *
      * @param node Node to serialize.
      * @param options Serialization options.
      */
-    constructor(node: T['parentNode'], options: SerializerOptions<T>) {
+    constructor(private node: T['parentNode'], private options: SerializerOptions<T>) {
         super({ encoding: 'utf8' });
-
-        this.serializer = new Serializer(node, options);
     }
 
     //Readable stream implementation
     override _read(): void {
-        this.push(this.serializer.serialize());
+        this.push(serializeChildNodes(this.node, this.options));
         this.push(null);
     }
 }

--- a/packages/parse5-serializer-stream/lib/index.ts
+++ b/packages/parse5-serializer-stream/lib/index.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'node:stream';
-import { serializeChildNodes, SerializerOptions } from 'parse5/dist/serializer/index.js';
+import { serialize, type SerializerOptions } from 'parse5/dist/serializer/index.js';
 import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
 
 /**
@@ -34,7 +34,7 @@ export class SerializerStream<T extends TreeAdapterTypeMap> extends Readable {
 
     //Readable stream implementation
     override _read(): void {
-        this.push(serializeChildNodes(this.node, this.options));
+        this.push(serialize(this.node, this.options));
         this.push(null);
     }
 }

--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -4,7 +4,7 @@ import type { DefaultTreeAdapterMap } from './tree-adapters/default.js';
 import type { TreeAdapterTypeMap } from './tree-adapters/interface.js';
 
 export { ParserOptions } from './parser/index.js';
-export { serialize, SerializerOptions } from './serializer/index.js';
+export { serialize, serializeOuter, SerializerOptions } from './serializer/index.js';
 
 // Shorthands
 

--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -1,11 +1,10 @@
 import { Parser, ParserOptions } from './parser/index.js';
-import { serializeChildNodes, SerializerOptions } from './serializer/index.js';
+
 import type { DefaultTreeAdapterMap } from './tree-adapters/default.js';
-import * as DefaultTreeAdapter from './tree-adapters/default.js';
 import type { TreeAdapterTypeMap } from './tree-adapters/interface.js';
 
 export { ParserOptions } from './parser/index.js';
-export { SerializerOptions } from './serializer/index.js';
+export { serialize, SerializerOptions } from './serializer/index.js';
 
 // Shorthands
 
@@ -81,34 +80,4 @@ export function parseFragment<T extends TreeAdapterTypeMap = DefaultTreeAdapterM
     const parser = new Parser(options);
 
     return parser.parseFragment(html as string, fragmentContext);
-}
-
-/**
- * Serializes an AST node to an HTML string.
- *
- * @example
- *
- * ```js
- * const parse5 = require('parse5');
- *
- * const document = parse5.parse('<!DOCTYPE html><html><head></head><body>Hi there!</body></html>');
- *
- * // Serializes a document.
- * const html = parse5.serialize(document);
- *
- * // Serializes the <html> element content.
- * const str = parse5.serialize(document.childNodes[1]);
- *
- * console.log(str); //> '<head></head><body>Hi there!</body>'
- * ```
- *
- * @param node Node to serialize.
- * @param options Serialization options.
- */
-export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
-    node: T['parentNode'],
-    options: Partial<SerializerOptions<T>>
-): string {
-    const opts = { treeAdapter: DefaultTreeAdapter, ...options };
-    return serializeChildNodes(node, opts);
 }

--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -1,6 +1,7 @@
 import { Parser, ParserOptions } from './parser/index.js';
-import { Serializer, SerializerOptions } from './serializer/index.js';
+import { serializeChildNodes, SerializerOptions } from './serializer/index.js';
 import type { DefaultTreeAdapterMap } from './tree-adapters/default.js';
+import * as DefaultTreeAdapter from './tree-adapters/default.js';
 import type { TreeAdapterTypeMap } from './tree-adapters/interface.js';
 
 export { ParserOptions } from './parser/index.js';
@@ -106,9 +107,8 @@ export function parseFragment<T extends TreeAdapterTypeMap = DefaultTreeAdapterM
  */
 export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
     node: T['parentNode'],
-    options: SerializerOptions<T>
+    options: Partial<SerializerOptions<T>>
 ): string {
-    const serializer = new Serializer(node, options);
-
-    return serializer.serialize();
+    const opts = { treeAdapter: DefaultTreeAdapter, ...options };
+    return serializeChildNodes(node, opts);
 }

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert';
 import * as parse5 from 'parse5';
+import outdent from 'outdent';
 import { generateSerializerTests } from 'parse5-test-utils/utils/generate-serializer-tests.js';
 import { treeAdapters } from 'parse5-test-utils/utils/common.js';
 import type { Element } from 'parse5/dist/tree-adapters/default';
@@ -32,6 +33,20 @@ describe('serializer', () => {
             expect(parse5.serialize(document, { scriptingEnabled: true })).toBe(
                 '<html><head></head><body>&amp;<noscript>&amp;</noscript></body></html>'
             );
+        });
+    });
+
+    describe('Mixed content (GH-333)', () => {
+        it('should serialize mixed content', () => {
+            const input = outdent`
+              <svg><style>&lt;</style></svg>
+              <style>&lt;</style>
+
+              <svg><script>&lt;</script></svg>
+              <script>&lt;</script>
+            `;
+            const document = parse5.parse(input);
+            expect(parse5.serialize(document)).toContain(input);
         });
     });
 });

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -22,4 +22,16 @@ describe('serializer', () => {
             parse5.serialize(document, { treeAdapter });
         });
     });
+
+    describe('Scripting flag (GH-332)', () => {
+        it('should serialize with the scripting flag', () => {
+            const document = parse5.parse('&amp;<noscript>&amp;</noscript>');
+            expect(parse5.serialize(document, { scriptingEnabled: false })).toBe(
+                '<html><head></head><body>&amp;<noscript>&amp;amp;</noscript></body></html>'
+            );
+            expect(parse5.serialize(document, { scriptingEnabled: true })).toBe(
+                '<html><head></head><body>&amp;<noscript>&amp;</noscript></body></html>'
+            );
+        });
+    });
 });

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'node:assert';
 import * as parse5 from 'parse5';
-import outdent from 'outdent';
 import { generateSerializerTests } from 'parse5-test-utils/utils/generate-serializer-tests.js';
 import { treeAdapters } from 'parse5-test-utils/utils/common.js';
 import { type Element, isElementNode } from 'parse5/dist/tree-adapters/default';
@@ -21,32 +20,6 @@ describe('serializer', () => {
             };
 
             parse5.serialize(document, { treeAdapter });
-        });
-    });
-
-    describe('Scripting flag (GH-332)', () => {
-        it('should serialize with the scripting flag', () => {
-            const document = parse5.parse('&amp;<noscript>&amp;</noscript>');
-            expect(parse5.serialize(document, { scriptingEnabled: false })).toBe(
-                '<html><head></head><body>&amp;<noscript>&amp;amp;</noscript></body></html>'
-            );
-            expect(parse5.serialize(document, { scriptingEnabled: true })).toBe(
-                '<html><head></head><body>&amp;<noscript>&amp;</noscript></body></html>'
-            );
-        });
-    });
-
-    describe('Mixed content (GH-333)', () => {
-        it('should serialize mixed content', () => {
-            const input = outdent`
-              <svg><style>&lt;</style></svg>
-              <style>&lt;</style>
-
-              <svg><script>&lt;</script></svg>
-              <script>&lt;</script>
-            `;
-            const document = parse5.parse(input);
-            expect(parse5.serialize(document)).toContain(input);
         });
     });
 

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -33,4 +33,13 @@ describe('serializer', () => {
             assert.equal(html, '<div><button>Hello</button></div>');
         });
     });
+
+    it('serializes <template> elements inner content', () => {
+        const document = parse5.parseFragment('<template><button>Hello</button></template>');
+        const template = document.childNodes[0];
+        assert.ok(isElementNode(template));
+        const html = parse5.serialize(template);
+
+        assert.equal(html, '<button>Hello</button>');
+    });
 });

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -3,7 +3,7 @@ import * as parse5 from 'parse5';
 import outdent from 'outdent';
 import { generateSerializerTests } from 'parse5-test-utils/utils/generate-serializer-tests.js';
 import { treeAdapters } from 'parse5-test-utils/utils/common.js';
-import type { Element } from 'parse5/dist/tree-adapters/default';
+import { type Element, isElementNode } from 'parse5/dist/tree-adapters/default';
 
 generateSerializerTests('serializer', 'Serializer', parse5.serialize);
 
@@ -47,6 +47,17 @@ describe('serializer', () => {
             `;
             const document = parse5.parse(input);
             expect(parse5.serialize(document)).toContain(input);
+        });
+    });
+
+    describe('serializeOuter', () => {
+        it('serializes outerHTML correctly', () => {
+            const document = parse5.parseFragment('<div><button>Hello</button></div>');
+            const div = document.childNodes[0];
+            assert.ok(isElementNode(div));
+            const html = parse5.serializeOuter(div);
+
+            assert.equal(html, '<div><button>Hello</button></div>');
         });
     });
 });

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -50,6 +50,8 @@ export interface SerializerOptions<T extends TreeAdapterTypeMap> {
 
 type InternalOptions<T extends TreeAdapterTypeMap> = Required<SerializerOptions<T>>;
 
+const defaultOpts = { treeAdapter: DefaultTreeAdapter, scriptingEnabled: true };
+
 /**
  * Serializes an AST node to an HTML string.
  *
@@ -76,8 +78,35 @@ export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapter.Defa
     node: T['parentNode'],
     options?: SerializerOptions<T>
 ): string {
-    const opts = { treeAdapter: DefaultTreeAdapter, scriptingEnabled: true, ...options };
+    const opts = { ...defaultOpts, ...options };
     return serializeChildNodes(node, opts);
+}
+
+/**
+ * Serializes an AST element node to an HTML string, including the element node.
+ *
+ * @example
+ *
+ * ```js
+ * const parse5 = require('parse5');
+ *
+ * const document = parse5.parseFragment('<div>Hello, <b>world</b>!</div>');
+ *
+ * // Serializes the <div> element.
+ * const html = parse5.serializeOuter(document.childNodes[0]);
+ *
+ * console.log(str); //> '<div>Hello, <b>world</b>!</div>'
+ * ```
+ *
+ * @param node Node to serialize.
+ * @param options Serialization options.
+ */
+export function serializeOuter<T extends TreeAdapterTypeMap = DefaultTreeAdapter.DefaultTreeAdapterMap>(
+    node: T['element'],
+    options?: SerializerOptions<T>
+): string {
+    const opts = { ...defaultOpts, ...options };
+    return serializeElement(node, opts);
 }
 
 function serializeChildNodes<T extends TreeAdapterTypeMap>(

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -79,14 +79,15 @@ export function serializeElement<T extends TreeAdapterTypeMap>(
     options: SerializerOptions<T>
 ): string {
     const tn = options.treeAdapter.getTagName(node);
-    const ns = options.treeAdapter.getNamespaceURI(node);
 
     return `<${tn}${serializeAttributes(node, options)}>${
         VOID_ELEMENTS.has(tn)
             ? ''
             : `${serializeChildNodes(
                   // Get container of the child nodes
-                  tn === $.TEMPLATE && ns === NS.HTML ? options.treeAdapter.getTemplateContent(node) : node,
+                  tn === $.TEMPLATE && options.treeAdapter.getNamespaceURI(node) === NS.HTML
+                      ? options.treeAdapter.getTemplateContent(node)
+                      : node,
                   options
               )}</${tn}>`
     }`;

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -114,7 +114,14 @@ function serializeChildNodes<T extends TreeAdapterTypeMap>(
     options: InternalOptions<T>
 ): string {
     let html = '';
-    const childNodes = options.treeAdapter.getChildNodes(parentNode);
+    // Get container of the child nodes
+    const container =
+        options.treeAdapter.isElementNode(parentNode) &&
+        options.treeAdapter.getTagName(parentNode) === $.TEMPLATE &&
+        options.treeAdapter.getNamespaceURI(parentNode) === NS.HTML
+            ? options.treeAdapter.getTemplateContent(parentNode)
+            : parentNode;
+    const childNodes = options.treeAdapter.getChildNodes(container);
 
     if (childNodes) {
         for (const currentNode of childNodes) {
@@ -139,13 +146,7 @@ function serializeElement<T extends TreeAdapterTypeMap>(node: T['element'], opti
     return `<${tn}${serializeAttributes(node, options)}>${
         options.treeAdapter.getNamespaceURI(node) === NS.HTML && VOID_ELEMENTS.has(tn)
             ? ''
-            : `${serializeChildNodes(
-                  // Get container of the child nodes
-                  tn === $.TEMPLATE && options.treeAdapter.getNamespaceURI(node) === NS.HTML
-                      ? options.treeAdapter.getTemplateContent(node)
-                      : node,
-                  options
-              )}</${tn}>`
+            : `${serializeChildNodes(node, options)}</${tn}>`
     }`;
 }
 

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -74,7 +74,7 @@ type InternalOptions<T extends TreeAdapterTypeMap> = Required<SerializerOptions<
  */
 export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapter.DefaultTreeAdapterMap>(
     node: T['parentNode'],
-    options: SerializerOptions<T>
+    options?: SerializerOptions<T>
 ): string {
     const opts = { treeAdapter: DefaultTreeAdapter, scriptingEnabled: true, ...options };
     return serializeChildNodes(node, opts);
@@ -108,7 +108,7 @@ function serializeElement<T extends TreeAdapterTypeMap>(node: T['element'], opti
     const tn = options.treeAdapter.getTagName(node);
 
     return `<${tn}${serializeAttributes(node, options)}>${
-        VOID_ELEMENTS.has(tn)
+        options.treeAdapter.getNamespaceURI(node) === NS.HTML && VOID_ELEMENTS.has(tn)
             ? ''
             : `${serializeChildNodes(
                   // Get container of the child nodes
@@ -165,7 +165,9 @@ function serializeTextNode<T extends TreeAdapterTypeMap>(node: T['textNode'], op
     const parent = treeAdapter.getParentNode(node);
     const parentTn = parent && treeAdapter.isElementNode(parent) && treeAdapter.getTagName(parent);
 
-    return parentTn && (UNESCAPED_TEXT.has(parentTn) || (options.scriptingEnabled && parentTn === $.NOSCRIPT))
+    return parentTn &&
+        treeAdapter.getNamespaceURI(parent) === NS.HTML &&
+        (UNESCAPED_TEXT.has(parentTn) || (options.scriptingEnabled && parentTn === $.NOSCRIPT))
         ? content
         : escapeString(content, false);
 }

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -1,4 +1,3 @@
-import * as doctype from '../common/doctype.js';
 import { TAG_NAMES as $, NAMESPACES as NS } from '../common/html.js';
 import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface';
 
@@ -155,9 +154,7 @@ function serializeDocumentTypeNode<T extends TreeAdapterTypeMap>(
     node: T['documentType'],
     { treeAdapter }: SerializerOptions<T>
 ): string {
-    const name = treeAdapter.getDocumentTypeNodeName(node);
-
-    return `<${doctype.serializeContent(name, null, null)}>`;
+    return `<!DOCTYPE ${treeAdapter.getDocumentTypeNodeName(node)}>`;
 }
 
 // NOTE: used in tests and by rewriting stream

--- a/test/data/serialization/tests.json
+++ b/test/data/serialization/tests.json
@@ -141,7 +141,7 @@
         "expected": "<html><head></head><body><pre>1</pre><pre>\n2</pre><textarea>3</textarea><textarea>\n4</textarea><listing>5</listing><listing>\n6</listing></body></html>"
     },
     {
-        "name": "Mixed content",
+        "name": "Mixed content (GH-333)",
         "input": "<svg><style>&lt;</style></svg><style>&lt;</style><svg><script>&lt;</script></svg><script>&lt;</script>",
         "expected": "<html><head></head><body><svg><style>&lt;</style></svg><style>&lt;</style><svg><script>&lt;</script></svg><script>&lt;</script></body></html>"
     }

--- a/test/data/serialization/tests.json
+++ b/test/data/serialization/tests.json
@@ -100,6 +100,12 @@
         "expected": "<html><head></head><body><noscript>& ><</noscript></body></html>"
     },
     {
+        "name": "Text nodes escaping - <noscript> with scripting disabled (GH-332)",
+        "options": { "scriptingEnabled": false },
+        "input": "<body><noscript>& ><</noscript></body>",
+        "expected": "<html><head></head><body><noscript>&amp; &gt;&lt;</noscript></body></html>"
+    },
+    {
         "name": "Comment nodes",
         "input": "<!-- Hey --><html><head></head><!-- &\u00A0>< --><body><!-- 42 --></body></html>",
         "expected": "<!-- Hey --><html><head></head><!-- &\u00A0>< --><body><!-- 42 --></body></html>"
@@ -133,5 +139,10 @@
         "name": "<pre>, <textarea>, <listing> with initial LF (see: https://github.com/whatwg/html/pull/1815)",
         "input": "<pre>\n1</pre><pre>\n\n2</pre><textarea>\n3</textarea><textarea>\n\n4</textarea><listing>\n5</listing><listing>\n\n6</listing>",
         "expected": "<html><head></head><body><pre>1</pre><pre>\n2</pre><textarea>3</textarea><textarea>\n4</textarea><listing>5</listing><listing>\n6</listing></body></html>"
+    },
+    {
+        "name": "Mixed content",
+        "input": "<svg><style>&lt;</style></svg><style>&lt;</style><svg><script>&lt;</script></svg><script>&lt;</script>",
+        "expected": "<html><head></head><body><svg><style>&lt;</style></svg><style>&lt;</style><svg><script>&lt;</script></svg><script>&lt;</script></body></html>"
     }
 ]

--- a/test/utils/generate-serializer-tests.ts
+++ b/test/utils/generate-serializer-tests.ts
@@ -15,6 +15,7 @@ export function generateSerializerTests(
     const data = fs.readFileSync(new URL('../data/serialization/tests.json', import.meta.url)).toString('utf-8');
     const tests = JSON.parse(data) as {
         name: string;
+        options?: parse5.SerializerOptions<TreeAdapterTypeMap>;
         input: string;
         expected: string;
     }[];
@@ -22,7 +23,7 @@ export function generateSerializerTests(
     generateTestsForEachTreeAdapter(name, (treeAdapter) => {
         for (const [idx, test] of tests.entries()) {
             it(`${prefix} - ${idx}.${test.name}`, async () => {
-                const opts = { treeAdapter };
+                const opts = { ...test.options, treeAdapter };
                 const document = parse5.parse(test.input, opts);
                 const serializedResult = await serialize(document, opts);
 


### PR DESCRIPTION
Simplifies the serializer by removing the wrapping class, fixes mixed content (#333), adds the scripting flag (#332), and adds a `serializeOuter` method (#230, #378). Also fixes passing a `<template>` element to `serialize` resulting in an empty string.

The `parse5-serializer-stream` module should be deprecated after these changes.