### PR TITLE
refactor(parser): Remove `_bootstrap` method

### DIFF
--- a/packages/parse5-parser-stream/lib/index.ts
+++ b/packages/parse5-parser-stream/lib/index.ts
@@ -1,5 +1,5 @@
 import { Writable } from 'node:stream';
-import { Parser, ParserOptions, defaultParserOptions } from 'parse5/dist/parser/index.js';
+import { Parser, ParserOptions } from 'parse5/dist/parser/index.js';
 import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
 import type { DefaultTreeAdapterMap } from 'parse5/dist/tree-adapters/default.js';
 
@@ -42,8 +42,7 @@ export class ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> 
     constructor(options?: ParserOptions<T>) {
         super({ decodeStrings: false });
 
-        const opts = { ...defaultParserOptions, ...options };
-        this.parser = new Parser(opts);
+        this.parser = new Parser(options);
         this.document = this.parser.document;
     }
 

--- a/packages/parse5-parser-stream/lib/index.ts
+++ b/packages/parse5-parser-stream/lib/index.ts
@@ -1,5 +1,5 @@
 import { Writable } from 'node:stream';
-import { Parser, ParserOptions } from 'parse5/dist/parser/index.js';
+import { Parser, ParserOptions, defaultParserOptions } from 'parse5/dist/parser/index.js';
 import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
 import type { DefaultTreeAdapterMap } from 'parse5/dist/tree-adapters/default.js';
 
@@ -42,10 +42,9 @@ export class ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> 
     constructor(options?: ParserOptions<T>) {
         super({ decodeStrings: false });
 
-        this.parser = new Parser(options);
-
-        this.document = this.parser.treeAdapter.createDocument();
-        this.parser._bootstrap(this.document, null);
+        const opts = { ...defaultParserOptions, ...options };
+        this.parser = new Parser(opts);
+        this.document = this.parser.document;
     }
 
     //WritableStream implementation

--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -29,9 +29,7 @@ export function parse<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
     html: string,
     options?: ParserOptions<T>
 ): T['document'] {
-    const parser = new Parser(options);
-
-    return parser.parse(html);
+    return Parser.parse(html, options);
 }
 
 /**
@@ -77,9 +75,7 @@ export function parseFragment<T extends TreeAdapterTypeMap = DefaultTreeAdapterM
         fragmentContext = null;
     }
 
-    const parser = new Parser(options);
-
-    return parser.parseFragment(html as string, fragmentContext);
+    return Parser.parseFragment(html as string, fragmentContext, options);
 }
 
 /**

--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -6,7 +6,7 @@ import { generateParsingTests } from 'parse5-test-utils/utils/generate-parsing-t
 import { treeAdapters } from 'parse5-test-utils/utils/common.js';
 import { NAMESPACES as NS } from '../common/html.js';
 
-const origParseFragment = Parser.prototype.parseFragment;
+const origParseFragment = Parser.parseFragment;
 
 generateParsingTests('parser', 'Parser', {}, (test, opts) => ({
     node: test.fragmentContext
@@ -25,21 +25,25 @@ describe('parser', () => {
 
     describe('Regression - Incorrect arguments fallback for the parser.parseFragment (GH-82, GH-83)', () => {
         beforeEach(() => {
-            Parser.prototype.parseFragment = function <T extends TreeAdapterTypeMap>(
-                this: Parser<T>,
+            Parser.parseFragment = function <T extends TreeAdapterTypeMap>(
                 html: string,
-                fragmentContext?: T['element']
-            ): { html: string; fragmentContext: T['element'] | null | undefined; options: ParserOptions<T> } {
+                fragmentContext?: T['element'],
+                options?: ParserOptions<T>
+            ): {
+                html: string;
+                fragmentContext: T['element'] | null | undefined;
+                options: ParserOptions<T> | undefined;
+            } {
                 return {
                     html,
                     fragmentContext,
-                    options: this.options,
+                    options,
                 };
             };
         });
 
         afterEach(() => {
-            Parser.prototype.parseFragment = origParseFragment;
+            Parser.parseFragment = origParseFragment;
         });
 
         it('parses correctly', () => {
@@ -63,7 +67,7 @@ describe('parser', () => {
 
             assert.ok(!args.fragmentContext);
             expect(args).toHaveProperty('html', html);
-            assert.ok(!args.options.sourceCodeLocationInfo);
+            assert.ok(!args.options);
         });
     });
 

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -82,7 +82,7 @@ export interface ParserOptions<T extends TreeAdapterTypeMap> {
      *
      *  @default `true`
      */
-    scriptingEnabled?: boolean | undefined;
+    scriptingEnabled?: boolean;
 
     /**
      * Enables source code location information. When enabled, each node (except the root node)
@@ -94,14 +94,14 @@ export interface ParserOptions<T extends TreeAdapterTypeMap> {
      *
      * @default `false`
      */
-    sourceCodeLocationInfo?: boolean | undefined;
+    sourceCodeLocationInfo?: boolean;
 
     /**
      * Specifies the resulting tree format.
      *
      * @default `treeAdapters.default`
      */
-    treeAdapter?: TreeAdapter<T> | undefined;
+    treeAdapter?: TreeAdapter<T>;
 
     /**
      * Callback for parse errors.
@@ -111,20 +111,24 @@ export interface ParserOptions<T extends TreeAdapterTypeMap> {
     onParseError?: ParserErrorHandler | null;
 }
 
+export const defaultParserOptions = {
+    scriptingEnabled: true,
+    sourceCodeLocationInfo: false,
+    treeAdapter: defaultTreeAdapter,
+    onParseError: null,
+};
+
 //Parser
 export class Parser<T extends TreeAdapterTypeMap> {
-    options: ParserOptions<T>;
     treeAdapter: TreeAdapter<T>;
     private onParseError: ParserErrorHandler | null;
     private currentToken: Token | null = null;
 
-    constructor(options?: ParserOptions<T>) {
-        this.options = {
-            scriptingEnabled: true,
-            sourceCodeLocationInfo: false,
-            ...options,
-        };
-
+    public constructor(
+        public options: Required<ParserOptions<T>>,
+        public document: T['document'] = options.treeAdapter.createDocument(),
+        public fragmentContext: T['element'] | null = null
+    ) {
         this.treeAdapter = this.options.treeAdapter ??= defaultTreeAdapter as TreeAdapter<T>;
         this.onParseError = this.options.onParseError ??= null;
 
@@ -132,65 +136,90 @@ export class Parser<T extends TreeAdapterTypeMap> {
         if (this.onParseError) {
             this.options.sourceCodeLocationInfo = true;
         }
+
+        this.tokenizer = new Tokenizer(this.options);
+        this.activeFormattingElements = new FormattingElementList(this.treeAdapter);
+
+        this.fragmentContextID = fragmentContext ? getTagID(this.treeAdapter.getTagName(fragmentContext)) : $.UNKNOWN;
+        this._setContextModes(fragmentContext ?? document, this.fragmentContextID);
+
+        this.openElements = new OpenElementStack(
+            this.document,
+            this.treeAdapter,
+            this.onItemPush.bind(this),
+            this.onItemPop.bind(this)
+        );
     }
 
     // API
-    public parse(html: string): T['document'] {
-        const document = this.treeAdapter.createDocument();
+    public static parse<T extends TreeAdapterTypeMap>(html: string, options?: ParserOptions<T>): T['document'] {
+        const opts = {
+            ...defaultParserOptions,
+            ...options,
+        };
 
-        this._bootstrap(document, null);
-        this.tokenizer.write(html, true);
-        this._runParsingLoop(null);
+        const parser = new this(opts);
 
-        return document;
+        parser.tokenizer.write(html, true);
+        parser._runParsingLoop(null);
+
+        return parser.document;
     }
 
-    public parseFragment(html: string, fragmentContext?: T['parentNode'] | null): T['documentFragment'] {
+    public static parseFragment<T extends TreeAdapterTypeMap>(
+        html: string,
+        fragmentContext?: T['parentNode'] | null,
+        options?: ParserOptions<T>
+    ): T['documentFragment'] {
+        const opts: Required<ParserOptions<T>> = {
+            ...defaultParserOptions,
+            ...options,
+        };
+
         //NOTE: use <template> element as a fragment context if context element was not provided,
         //so we will parse in "forgiving" manner
-        fragmentContext ??= this.treeAdapter.createElement(TN.TEMPLATE, NS.HTML, []);
+        fragmentContext ??= opts.treeAdapter.createElement(TN.TEMPLATE, NS.HTML, []);
 
         //NOTE: create fake element which will be used as 'document' for fragment parsing.
         //This is important for jsdom there 'document' can't be recreated, therefore
         //fragment parsing causes messing of the main `document`.
-        const documentMock = this.treeAdapter.createElement('documentmock', NS.HTML, []);
+        const documentMock = opts.treeAdapter.createElement('documentmock', NS.HTML, []);
 
-        this._bootstrap(documentMock, fragmentContext);
+        const parser = new this(opts, documentMock, fragmentContext);
 
-        if (this.fragmentContextID === $.TEMPLATE) {
-            this.tmplInsertionModeStack.unshift(InsertionMode.IN_TEMPLATE);
+        if (parser.fragmentContextID === $.TEMPLATE) {
+            parser.tmplInsertionModeStack.unshift(InsertionMode.IN_TEMPLATE);
         }
 
-        this._initTokenizerForFragmentParsing();
-        this._insertFakeRootElement();
-        this._resetInsertionMode();
-        this._findFormInFragmentContext();
-        this.tokenizer.write(html, true);
-        this._runParsingLoop(null);
+        parser._initTokenizerForFragmentParsing();
+        parser._insertFakeRootElement();
+        parser._resetInsertionMode();
+        parser._findFormInFragmentContext();
+        parser.tokenizer.write(html, true);
+        parser._runParsingLoop(null);
 
-        const rootElement = this.treeAdapter.getFirstChild(documentMock) as T['parentNode'];
-        const fragment = this.treeAdapter.createDocumentFragment();
+        const rootElement = opts.treeAdapter.getFirstChild(documentMock) as T['parentNode'];
+        const fragment = opts.treeAdapter.createDocumentFragment();
 
-        this._adoptNodes(rootElement, fragment);
+        parser._adoptNodes(rootElement, fragment);
 
         return fragment;
     }
 
-    tokenizer!: Tokenizer;
+    tokenizer: Tokenizer;
+
     stopped = false;
     insertionMode = InsertionMode.INITIAL;
     originalInsertionMode = InsertionMode.INITIAL;
 
-    document!: T['document'];
-    fragmentContext!: T['element'] | null;
-    fragmentContextID = $.UNKNOWN;
+    fragmentContextID: $;
 
     headElement: null | T['element'] = null;
     formElement: null | T['element'] = null;
     pendingScript: null | T['element'] = null;
 
-    openElements!: OpenElementStack<T>;
-    activeFormattingElements!: FormattingElementList<T>;
+    openElements: OpenElementStack<T>;
+    activeFormattingElements: FormattingElementList<T>;
     private _considerForeignContent = false;
 
     /**
@@ -205,44 +234,6 @@ export class Parser<T extends TreeAdapterTypeMap> {
     framesetOk = true;
     skipNextNewLine = false;
     fosterParentingEnabled = false;
-
-    //Bootstrap parser
-    _bootstrap(document: T['document'], fragmentContext: T['element'] | null): void {
-        this.tokenizer = new Tokenizer(this.options);
-
-        this.stopped = false;
-
-        this.insertionMode = InsertionMode.INITIAL;
-        this.originalInsertionMode = InsertionMode.INITIAL;
-
-        this.document = document;
-        this.fragmentContext = fragmentContext;
-        this.fragmentContextID = fragmentContext ? getTagID(this.treeAdapter.getTagName(fragmentContext)) : $.UNKNOWN;
-        this._setContextModes(fragmentContext ?? document, this.fragmentContextID);
-
-        this.headElement = null;
-        this.formElement = null;
-        this.pendingScript = null;
-        this.currentToken = null;
-
-        this.openElements = new OpenElementStack(
-            this.document,
-            this.treeAdapter,
-            this.onItemPush.bind(this),
-            this.onItemPop.bind(this)
-        );
-
-        this.activeFormattingElements = new FormattingElementList(this.treeAdapter);
-
-        this.tmplInsertionModeStack.length = 0;
-
-        this.pendingCharacterTokens.length = 0;
-        this.hasNonWhitespacePendingCharacterToken = false;
-
-        this.framesetOk = true;
-        this.skipNextNewLine = false;
-        this.fosterParentingEnabled = false;
-    }
 
     //Errors
     _err(token: Token, code: ERR, beforeToken?: boolean): void {

--- a/scripts/generate-parser-feedback-test/index.ts
+++ b/scripts/generate-parser-feedback-test/index.ts
@@ -6,6 +6,7 @@ import { convertTokenToHtml5Lib } from 'parse5-test-utils/utils/generate-tokeniz
 import { parseDatFile } from 'parse5-test-utils/utils/parse-dat-file.js';
 import { addSlashes } from 'parse5-test-utils/utils/common.js';
 import { TokenType, Token } from '../../packages/parse5/dist/common/token.js';
+import type { TreeAdapterTypeMap } from '../../packages/parse5/dist/tree-adapters/interface.js';
 
 // eslint-disable-next-line no-console
 main().catch(console.error);
@@ -42,21 +43,22 @@ function appendToken(dest: Token[], token: Token): void {
 
 function collectParserTokens(html: string): ReturnType<typeof convertTokenToHtml5Lib>[] {
     const tokens: Token[] = [];
-    const parser = new Parser();
 
-    parser._processInputToken = function (token): void {
-        Parser.prototype._processInputToken.call(this, token);
+    class ExtendedParser<T extends TreeAdapterTypeMap> extends Parser<T> {
+        override _processInputToken(token: Token): void {
+            super._processInputToken(token);
 
-        // NOTE: Needed to split attributes of duplicate <html> and <body>
-        // which are otherwise merged as per tree constructor spec
-        if (token.type === TokenType.START_TAG) {
-            token.attrs = [...token.attrs];
+            // NOTE: Needed to split attributes of duplicate <html> and <body>
+            // which are otherwise merged as per tree constructor spec
+            if (token.type === TokenType.START_TAG) {
+                token.attrs = [...token.attrs];
+            }
+
+            appendToken(tokens, token);
         }
+    }
 
-        appendToken(tokens, token);
-    };
-
-    parser.parse(html);
+    ExtendedParser.parse(html);
 
     return tokens.map((token) => convertTokenToHtml5Lib(token));
 }


### PR DESCRIPTION
The `_bootstrap` method leaves the parser in a broken-by-design state, which requires us to use non-null assertions to make TS happy. This PR removes this method, moving its arguments to the constructor.

This helps considerably with #377.