### PR TITLE
feat(parser): Add hooks for stack events

### DIFF
--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -117,11 +117,15 @@ describe('parser', () => {
             assert.ok(isElementNode(htmlElement));
             const bodyElement = htmlElement.childNodes[1];
             assert.ok(isElementNode(bodyElement));
+            // Expect 5 opened elements; in order: html, head, body, and 2x p
             expect(onItemPush).toHaveBeenCalledTimes(5);
             expect(onItemPush).toHaveBeenNthCalledWith(1, htmlElement);
             expect(onItemPush).toHaveBeenNthCalledWith(3, bodyElement);
+            // The last opened element is the second p
             expect(onItemPush).toHaveBeenLastCalledWith(bodyElement.childNodes[1]);
+            // The second p isn't closed, plus we never pop body and html. Alas, only 2 pop events (head and p).
             expect(onItemPop).toHaveBeenCalledTimes(2);
+            // The last pop event should be the first p.
             expect(onItemPop).toHaveBeenLastCalledWith(bodyElement.childNodes[0], bodyElement);
         });
     });

--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -122,7 +122,7 @@ describe('parser', () => {
             expect(onItemPush).toHaveBeenNthCalledWith(3, bodyElement);
             expect(onItemPush).toHaveBeenLastCalledWith(bodyElement.childNodes[1]);
             expect(onItemPop).toHaveBeenCalledTimes(2);
-            expect(onItemPop).toHaveBeenLastCalledWith(bodyElement.childNodes[0]);
+            expect(onItemPop).toHaveBeenLastCalledWith(bodyElement.childNodes[0], bodyElement);
         });
     });
 });

--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -101,13 +101,16 @@ describe('parser', () => {
         expect(doctype).toHaveProperty('systemId', '');
     });
 
-    describe('Options', () => {
+    describe('Tree adapters', () => {
         it('should support onItemPush and onItemPop', () => {
             const onItemPush = jest.fn();
             const onItemPop = jest.fn();
             const document = parse5.parse('<p><p>', {
-                onItemPush,
-                onItemPop,
+                treeAdapter: {
+                    ...treeAdapters.default,
+                    onItemPush,
+                    onItemPop,
+                },
             });
 
             const htmlElement = document.childNodes[0];

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -109,6 +109,22 @@ export interface ParserOptions<T extends TreeAdapterTypeMap> {
      * @default `null`
      */
     onParseError?: ParserErrorHandler | null;
+
+    /**
+     * Callback for elements being pushed to the stack of open elements.
+     *
+     * @default `null`
+     * @param element The element being pushed to the stack of open elements.
+     */
+    onItemPush?: ((item: T['element']) => void) | null;
+
+    /**
+     * Callback for elements being popped from the stack of open elements.
+     *
+     * @default `null`
+     * @param item The element being popped.
+     */
+    onItemPop?: ((item: T['element']) => void) | null;
 }
 
 //Parser
@@ -317,6 +333,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
 
     //Text parsing
     private onItemPush(node: T['parentNode'], tid: number, isTop: boolean): void {
+        this.options.onItemPush?.(node);
         if (isTop && this.openElements.stackTop > 0) this._setContextModes(node, tid);
     }
 
@@ -324,6 +341,8 @@ export class Parser<T extends TreeAdapterTypeMap> {
         if (this.options.sourceCodeLocationInfo) {
             this._setEndLocation(node, this.currentToken!);
         }
+
+        this.options.onItemPop?.(node);
 
         if (isTop) {
             let current;

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -326,7 +326,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             this._setEndLocation(node, this.currentToken!);
         }
 
-        this.treeAdapter.onItemPop?.(node);
+        this.treeAdapter.onItemPop?.(node, this.openElements.current);
 
         if (isTop) {
             let current;

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -109,22 +109,6 @@ export interface ParserOptions<T extends TreeAdapterTypeMap> {
      * @default `null`
      */
     onParseError?: ParserErrorHandler | null;
-
-    /**
-     * Callback for elements being pushed to the stack of open elements.
-     *
-     * @default `null`
-     * @param element The element being pushed to the stack of open elements.
-     */
-    onItemPush?: ((item: T['element']) => void) | null;
-
-    /**
-     * Callback for elements being popped from the stack of open elements.
-     *
-     * @default `null`
-     * @param item The element being popped.
-     */
-    onItemPop?: ((item: T['element']) => void) | null;
 }
 
 //Parser
@@ -333,7 +317,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
 
     //Text parsing
     private onItemPush(node: T['parentNode'], tid: number, isTop: boolean): void {
-        this.options.onItemPush?.(node);
+        this.treeAdapter.onItemPush?.(node);
         if (isTop && this.openElements.stackTop > 0) this._setContextModes(node, tid);
     }
 
@@ -342,7 +326,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             this._setEndLocation(node, this.currentToken!);
         }
 
-        this.options.onItemPop?.(node);
+        this.treeAdapter.onItemPop?.(node);
 
         if (isTop) {
             let current;

--- a/packages/parse5/lib/tree-adapters/interface.ts
+++ b/packages/parse5/lib/tree-adapters/interface.ts
@@ -292,5 +292,5 @@ export interface TreeAdapter<T extends TreeAdapterTypeMap = TreeAdapterTypeMap> 
      *
      * @param item The element being popped.
      */
-    onItemPop?: (item: T['element']) => void;
+    onItemPop?: (item: T['element'], newTop: T['parentNode']) => void;
 }

--- a/packages/parse5/lib/tree-adapters/interface.ts
+++ b/packages/parse5/lib/tree-adapters/interface.ts
@@ -279,4 +279,18 @@ export interface TreeAdapter<T extends TreeAdapterTypeMap = TreeAdapterTypeMap> 
      * @param contentElement -  Content element.
      */
     setTemplateContent(templateElement: T['template'], contentElement: T['documentFragment']): void;
+
+    /**
+     * Optional callback for elements being pushed to the stack of open elements.
+     *
+     * @param element The element being pushed to the stack of open elements.
+     */
+    onItemPush?: (item: T['element']) => void;
+
+    /**
+     * Optional callback for elements being popped from the stack of open elements.
+     *
+     * @param item The element being popped.
+     */
+    onItemPop?: (item: T['element']) => void;
 }


### PR DESCRIPTION
JSDOM currently monkey-patches parse5 to get these events. With this change, that is no longer necessary.

Fixes #237, #285.