### PR TITLE
refactor(tokenizer): Re-use object for current location

### DIFF
--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -269,7 +269,18 @@ export class Tokenizer {
     }
 
     private getStartLocation(): Location | null {
-        return this.ctLoc && { ...this.ctLoc };
+        if (this.ctLoc === null) {
+            return null;
+        }
+
+        return {
+            startLine: this.ctLoc.startLine,
+            startCol: this.ctLoc.startCol,
+            startOffset: this.ctLoc.startOffset,
+            endLine: -1,
+            endCol: -1,
+            endOffset: -1,
+        };
     }
 
     //API


### PR DESCRIPTION
Previously, `ctLoc` was overwritten on every new character. This change should lead to a great reduction in allocations when using location information.