### PR TITLE
refactor(parser): Invert event processing

### DIFF
--- a/packages/parse5-sax-parser/lib/parser-feedback-simulator.ts
+++ b/packages/parse5-sax-parser/lib/parser-feedback-simulator.ts
@@ -64,13 +64,13 @@ export class ParserFeedbackSimulator {
     private _enterNamespace(namespace: NS): void {
         this.namespaceStack.unshift(namespace);
         this.inForeignContent = namespace !== NS.HTML;
-        this.tokenizer.allowCDATA = this.inForeignContent;
+        this.tokenizer.inForeignNode = this.inForeignContent;
     }
 
     private _leaveCurrentNamespace(): void {
         this.namespaceStack.shift();
         this.inForeignContent = this.namespaceStack[0] !== NS.HTML;
-        this.tokenizer.allowCDATA = this.inForeignContent;
+        this.tokenizer.inForeignNode = this.inForeignContent;
     }
 
     //Token handlers

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -1120,7 +1120,6 @@ export class Parser<T extends TreeAdapterTypeMap> {
         }
     }
     onEof(token: EOFToken): void {
-        this.skipNextNewLine = false;
         switch (this.insertionMode) {
             case InsertionMode.INITIAL:
                 tokenInInitialMode(this, token);

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -579,35 +579,35 @@ export class Parser<T extends TreeAdapterTypeMap> {
     _processToken(token: Token): void {
         switch (token.type) {
             case TokenType.CHARACTER: {
-                this.onCharacterToken(token);
+                this.onCharacter(token);
                 break;
             }
             case TokenType.NULL_CHARACTER: {
-                this.onNullCharacterToken(token);
+                this.onNullCharacter(token);
                 break;
             }
             case TokenType.COMMENT: {
-                this.onCommentToken(token);
+                this.onComment(token);
                 break;
             }
             case TokenType.DOCTYPE: {
-                this.onDoctypeToken(token);
+                this.onDoctype(token);
                 break;
             }
             case TokenType.START_TAG: {
-                this.onStartTagToken(token);
+                this.onStartTag(token);
                 break;
             }
             case TokenType.END_TAG: {
-                this.onEndTagToken(token);
+                this.onEndTag(token);
                 break;
             }
             case TokenType.EOF: {
-                this.onEofToken(token);
+                this.onEof(token);
                 break;
             }
             case TokenType.WHITESPACE_CHARACTER: {
-                this.onWhitespaceCharacterToken(token);
+                this.onWhitespaceCharacter(token);
                 break;
             }
         }
@@ -779,7 +779,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
         return SPECIAL_ELEMENTS[ns].has(id);
     }
 
-    onCharacterToken(token: CharacterToken): void {
+    onCharacter(token: CharacterToken): void {
         this.skipNextNewLine = false;
 
         if (this.tokenizer.allowCDATA) {
@@ -838,7 +838,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             // Do nothing
         }
     }
-    onNullCharacterToken(token: CharacterToken): void {
+    onNullCharacter(token: CharacterToken): void {
         this.skipNextNewLine = false;
 
         if (this.tokenizer.allowCDATA) {
@@ -886,7 +886,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             // Do nothing
         }
     }
-    onCommentToken(token: CommentToken): void {
+    onComment(token: CommentToken): void {
         this.skipNextNewLine = false;
 
         if (this._considerForeignContent) {
@@ -929,7 +929,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             // Do nothing
         }
     }
-    onDoctypeToken(token: DoctypeToken): void {
+    onDoctype(token: DoctypeToken): void {
         this.skipNextNewLine = false;
         switch (this.insertionMode) {
             case InsertionMode.INITIAL:
@@ -948,7 +948,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             // Do nothing
         }
     }
-    onStartTagToken(token: TagToken): void {
+    onStartTag(token: TagToken): void {
         this.skipNextNewLine = false;
         this.currentToken = token;
 
@@ -1030,7 +1030,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             // Do nothing
         }
     }
-    onEndTagToken(token: TagToken): void {
+    onEndTag(token: TagToken): void {
         this.skipNextNewLine = false;
         this.currentToken = token;
 
@@ -1112,7 +1112,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             // Do nothing
         }
     }
-    onEofToken(token: EOFToken): void {
+    onEof(token: EOFToken): void {
         this.skipNextNewLine = false;
         switch (this.insertionMode) {
             case InsertionMode.INITIAL:
@@ -1164,7 +1164,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             // Do nothing
         }
     }
-    onWhitespaceCharacterToken(token: CharacterToken): void {
+    onWhitespaceCharacter(token: CharacterToken): void {
         if (this.skipNextNewLine) {
             this.skipNextNewLine = false;
 
@@ -2557,7 +2557,7 @@ function eofInText<T extends TreeAdapterTypeMap>(p: Parser<T>, token: EOFToken):
     p._err(token, ERR.eofInElementThatCanContainOnlyText);
     p.openElements.pop();
     p.insertionMode = p.originalInsertionMode;
-    p.onEofToken(token);
+    p.onEof(token);
 }
 
 // The "in table" insertion mode
@@ -2622,7 +2622,7 @@ function tableStartTagInTable<T extends TreeAdapterTypeMap>(p: Parser<T>, token:
     if (p.openElements.hasInTableScope($.TABLE)) {
         p.openElements.popUntilTagNamePopped($.TABLE);
         p._resetInsertionMode();
-        p.onStartTagToken(token);
+        p.onStartTag(token);
     }
 }
 
@@ -3122,7 +3122,7 @@ function startTagInSelect<T extends TreeAdapterTypeMap>(p: Parser<T>, token: Tag
                 p._resetInsertionMode();
 
                 if (token.tagID !== $.SELECT) {
-                    p.onStartTagToken(token);
+                    p.onStartTag(token);
                 }
             }
             break;
@@ -3192,7 +3192,7 @@ function startTagInSelectInTable<T extends TreeAdapterTypeMap>(p: Parser<T>, tok
     ) {
         p.openElements.popUntilTagNamePopped($.SELECT);
         p._resetInsertionMode();
-        p.onStartTagToken(token);
+        p.onStartTag(token);
     } else {
         startTagInSelect(p, token);
     }
@@ -3214,7 +3214,7 @@ function endTagInSelectInTable<T extends TreeAdapterTypeMap>(p: Parser<T>, token
         if (p.openElements.hasInTableScope(tn)) {
             p.openElements.popUntilTagNamePopped($.SELECT);
             p._resetInsertionMode();
-            p.onEndTagToken(token);
+            p.onEndTag(token);
         }
     } else {
         endTagInSelect(p, token);
@@ -3284,7 +3284,7 @@ function eofInTemplate<T extends TreeAdapterTypeMap>(p: Parser<T>, token: EOFTok
         p.activeFormattingElements.clearToLastMarker();
         p.tmplInsertionModeStack.shift();
         p._resetInsertionMode();
-        p.onEofToken(token);
+        p.onEof(token);
     } else {
         stopParsing(p, token);
     }

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -269,6 +269,10 @@ export class Parser<T extends TreeAdapterTypeMap> {
 
             this._processToken(token);
 
+            if (token.type === TokenType.START_TAG && token.selfClosing && !token.ackSelfClosing) {
+                this._err(token, ERR.nonVoidHtmlElementStartTagWithTrailingSolidus);
+            }
+
             if (token.type === TokenType.HIBERNATION || (scriptHandler !== null && this.pendingScript)) {
                 break;
             }
@@ -952,10 +956,6 @@ export class Parser<T extends TreeAdapterTypeMap> {
             startTagInForeignContent(this, token);
         } else {
             this._startTagOutsideForeignContent(token);
-        }
-
-        if (token.type === TokenType.START_TAG && token.selfClosing && !token.ackSelfClosing) {
-            this._err(token, ERR.nonVoidHtmlElementStartTagWithTrailingSolidus);
         }
     }
     _startTagOutsideForeignContent(token: TagToken): void {

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -1220,6 +1220,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
 //Adoption agency algorithm
 //(see: http://www.whatwg.org/specs/web-apps/current-work/multipage/tree-construction.html#adoptionAgency)
 //------------------------------------------------------------------
+
 //Steps 5-8 of the algorithm
 function aaObtainFormattingElementEntry<T extends TreeAdapterTypeMap>(
     p: Parser<T>,
@@ -1597,7 +1598,7 @@ function endTagInHead<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToke
 function tokenInHead<T extends TreeAdapterTypeMap>(p: Parser<T>, token: Token): void {
     p.openElements.pop();
     p.insertionMode = InsertionMode.AFTER_HEAD;
-    tokenAfterHead(p, token);
+    p._processToken(token);
 }
 
 // The "in head no script" insertion mode
@@ -1720,7 +1721,7 @@ function endTagAfterHead<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagT
 function tokenAfterHead<T extends TreeAdapterTypeMap>(p: Parser<T>, token: Token): void {
     p._insertFakeElement(TN.BODY, $.BODY);
     p.insertionMode = InsertionMode.IN_BODY;
-    p._processToken(token);
+    modeInBody(p, token);
 }
 
 // The "in body" insertion mode
@@ -3038,7 +3039,7 @@ function startTagInCell<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagTo
     if (TABLE_VOID_ELEMENTS.has(tn)) {
         if (p.openElements.hasInTableScope($.TD) || p.openElements.hasInTableScope($.TH)) {
             p._closeTableCell();
-            p.onStartTagToken(token);
+            startTagInRow(p, token);
         }
     } else {
         startTagInBody(p, token);
@@ -3066,7 +3067,7 @@ function endTagInCell<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToke
         case $.TR: {
             if (p.openElements.hasInTableScope(tn)) {
                 p._closeTableCell();
-                p.onEndTagToken(token);
+                endTagInRow(p, token);
             }
             break;
         }

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -572,20 +572,6 @@ export class Parser<T extends TreeAdapterTypeMap> {
             : !this._isIntegrationPoint(currentTagId, current);
     }
 
-    private shouldProcessTextInForeignContent(): boolean {
-        let current: T['parentNode'];
-        let currentTagId: number;
-
-        if (this.openElements.stackTop === 0 && this.fragmentContext) {
-            current = this.fragmentContext;
-            currentTagId = this.fragmentContextID;
-        } else {
-            ({ current, currentTagId } = this.openElements);
-        }
-
-        return !this._isIntegrationPoint(currentTagId, current);
-    }
-
     _processToken(token: Token): void {
         switch (token.type) {
             case TokenType.CHARACTER: {
@@ -791,7 +777,8 @@ export class Parser<T extends TreeAdapterTypeMap> {
 
     onCharacterToken(token: CharacterToken): void {
         this.skipNextNewLine = false;
-        if (this._considerForeignContent && this.shouldProcessTextInForeignContent()) {
+
+        if (this.tokenizer.allowCDATA) {
             characterInForeignContent(this, token);
             return;
         }
@@ -849,7 +836,8 @@ export class Parser<T extends TreeAdapterTypeMap> {
     }
     onNullCharacterToken(token: CharacterToken): void {
         this.skipNextNewLine = false;
-        if (this._considerForeignContent && this.shouldProcessTextInForeignContent()) {
+
+        if (this.tokenizer.allowCDATA) {
             nullCharacterInForeignContent(this, token);
             return;
         }
@@ -896,6 +884,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
     }
     onCommentToken(token: CommentToken): void {
         this.skipNextNewLine = false;
+
         if (this._considerForeignContent) {
             appendComment(this, token);
             return;
@@ -1188,7 +1177,7 @@ export class Parser<T extends TreeAdapterTypeMap> {
             }
         }
 
-        if (this._considerForeignContent && this.shouldProcessTextInForeignContent()) {
+        if (this.tokenizer.allowCDATA) {
             this._insertCharacters(token);
             return;
         }

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -213,7 +213,7 @@ export class Tokenizer {
      * Indicates that the current adjusted node exists, is not an element in the HTML namespace,
      * and that it is not an integration point for either MathML or HTML.
      *
-     * @see {@link https://html.spec.whatwg.org/#tree-construction}
+     * @see {@link https://html.spec.whatwg.org/multipage/parsing.html#tree-construction}
      */
     public inForeignNode = false;
     public lastStartTagName = '';

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -209,7 +209,13 @@ export class Tokenizer {
 
     private tokenQueue: Token[] = [];
 
-    public allowCDATA = false;
+    /**
+     * Indicates that the current adjusted node exists, is not an element in the HTML namespace,
+     * and that it is not an integration point for either MathML or HTML.
+     *
+     * @see {@link https://html.spec.whatwg.org/#tree-construction}
+     */
+    public inForeignNode = false;
     public lastStartTagName = '';
     public active = false;
 
@@ -1961,7 +1967,7 @@ export class Tokenizer {
         } else if (this._consumeSequenceIfMatch($$.DOCTYPE, false)) {
             this.state = State.DOCTYPE;
         } else if (this._consumeSequenceIfMatch($$.CDATA_START, true)) {
-            if (this.allowCDATA) {
+            if (this.inForeignNode) {
                 this.state = State.CDATA_SECTION;
             } else {
                 this._err(ERR.cdataInHtmlContent);

--- a/scripts/generate-parser-feedback-test/index.ts
+++ b/scripts/generate-parser-feedback-test/index.ts
@@ -44,8 +44,8 @@ function collectParserTokens(html: string): ReturnType<typeof convertTokenToHtml
     const tokens: Token[] = [];
     const parser = new Parser();
 
-    parser._processInputToken = function (token): void {
-        Parser.prototype._processInputToken.call(this, token);
+    parser._processToken = function (token): void {
+        Parser.prototype._processToken.call(this, token);
 
         // NOTE: Needed to split attributes of duplicate <html> and <body>
         // which are otherwise merged as per tree constructor spec


### PR DESCRIPTION
See #403 for details.

The parser currently first checks the insertion mode, and then the token type. By inverting this (checking first the token type, then the insertion mode), we prepare the parser to accept the events from #404.

This change also allowed foreign content checks to be greatly simplified.