### PR TITLE
fix(tokenizer): No parse error on attribute quirk

### DIFF
--- a/test/utils/generate-tokenization-tests.ts
+++ b/test/utils/generate-tokenization-tests.ts
@@ -14,17 +14,6 @@ interface TokenError {
     col: number;
 }
 
-const TestsWithBrokenErrors: Record<string, TokenError[]> = {
-    /*
-     * 57.entities has an error that is not part of the test data.
-     *
-     * TODO: Move this to the test data.
-     */
-    'Undefined named entity in attribute value ending in semicolon and whose name starts with a known entity name.': [
-        { code: 'unknown-named-character-reference', col: 12, line: 1 },
-    ],
-};
-
 interface TokenSourceData {
     tokens: HtmlLibToken[];
     errors: TokenError[];
@@ -222,9 +211,7 @@ function loadTests(dataDirPath: string): LoadedTest[] {
                     initialState: getTokenizerSuitableStateName(initialStateName),
                     initialStateName,
                     lastStartTag: descr.lastStartTag,
-                    expectedErrors: TestsWithBrokenErrors[descr.description]
-                        ? TestsWithBrokenErrors[descr.description]
-                        : descr.errors || [],
+                    expectedErrors: descr.errors || [],
                 });
             }
         }


### PR DESCRIPTION
Turns out a bug I _"fixed"_ in my fork (in https://github.com/inikulin/parse5/commit/70c1935552e90f23e2cbf4d0e2ce60d1da0b7e49) was actually the specced behaviour. This PR reintroduces the old behaviour.

Thanks to @untitaker for flagging this in https://github.com/html5lib/html5lib-tests/pull/144.