### PR TITLE
fix(tokenizer): Drop chunks after emitting tokens

### DIFF
--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
@@ -328,7 +328,7 @@ describe('RewritingStream', () => {
         parser.end();
     });
 
-    it.only('Should emit comment after text correctly', (done) => {
+    it('Should emit comment after text correctly', (done) => {
         const source = `${'a'.repeat((1 << 16) - 3)}<!-- foo -->`;
         const parser = new RewritingStream();
         let output = '';

--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
@@ -298,7 +298,7 @@ describe('RewritingStream', () => {
             assert.strictEqual(text, 'text');
         });
 
-        parser.once('finished', () => {
+        parser.once('finish', () => {
             assert.ok(foundText);
             done();
         });

--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
@@ -32,7 +32,7 @@ function createRewriterTest({
         const rewriter = new RewritingStream();
         const writable = new WritableStreamStub();
 
-        writable.once('finish', () => {
+        writable.once('close', () => {
             assert.ok(writable.writtenData === expected, getStringDiffMsg(writable.writtenData, expected));
             done();
         });
@@ -290,7 +290,7 @@ describe('RewritingStream', () => {
             assert.strictEqual(text, 'text');
         });
 
-        parser.once('finish', () => {
+        parser.once('close', () => {
             assert.ok(foundText);
             done();
         });

--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
@@ -305,4 +305,22 @@ describe('RewritingStream', () => {
 
         assert.throws(() => stream.write(buf), TypeError);
     });
+
+    it('Regression - RewritingStream - should pass long text correctly (GH-292)', (done) => {
+        const source = 'a'.repeat(65_540);
+        const parser = new RewritingStream();
+        let output = '';
+
+        parser.on('data', (data) => {
+            output += data.toString();
+        });
+
+        parser.once('finish', () => {
+            assert.strictEqual(output.length, source.length);
+            done();
+        });
+
+        parser.write(source);
+        parser.end();
+    });
 });

--- a/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
+++ b/packages/parse5-html-rewriting-stream/test/rewriting-stream.test.ts
@@ -3,6 +3,7 @@ import { outdent } from 'outdent';
 import { RewritingStream } from '../lib/index.js';
 import { loadSAXParserTestData } from 'parse5-test-utils/utils/load-sax-parser-test-data.js';
 import { getStringDiffMsg, writeChunkedToStream, WritableStreamStub } from 'parse5-test-utils/utils/common.js';
+import { finished } from 'node:stream';
 
 const srcHtml = outdent`
   <!DOCTYPE html "">
@@ -35,7 +36,7 @@ function createRewriterTest({
         const rewriter = new RewritingStream();
         const writable = new WritableStreamStub();
 
-        writable.once('close', () => {
+        finished(writable, () => {
             try {
                 assert.ok(writable.writtenData === expected, getStringDiffMsg(writable.writtenData, expected));
                 done();
@@ -297,7 +298,7 @@ describe('RewritingStream', () => {
             assert.strictEqual(text, 'text');
         });
 
-        parser.once('close', () => {
+        parser.once('finished', () => {
             assert.ok(foundText);
             done();
         });

--- a/packages/parse5-sax-parser/lib/index.ts
+++ b/packages/parse5-sax-parser/lib/index.ts
@@ -156,6 +156,10 @@ export class SAXParser extends Transform implements TokenHandler {
                 };
             }
         }
+
+        if (this.tokenizer.preprocessor.willDropParsedChunk()) {
+            this._emitPendingText();
+        }
     }
 
     /** @internal */

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -542,6 +542,7 @@ export class Tokenizer {
             if (this.currentCharacterToken.type !== type) {
                 this.currentLocation = this.getCurrentLocation(0);
                 this._emitCurrentCharacterToken(this.currentLocation);
+                this.preprocessor.dropParsedChunk();
             } else {
                 this.currentCharacterToken.chars += ch;
                 return;

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -465,16 +465,22 @@ export class Tokenizer {
 
             this.handler.onEndTag(ct);
         }
+
+        this.preprocessor.dropParsedChunk();
     }
 
     private emitCurrentComment(ct: CommentToken): void {
         this.prepareToken(ct);
         this.handler.onComment(ct);
+
+        this.preprocessor.dropParsedChunk();
     }
 
     private emitCurrentDoctype(ct: DoctypeToken): void {
         this.prepareToken(ct);
         this.handler.onDoctype(ct);
+
+        this.preprocessor.dropParsedChunk();
     }
 
     private _emitCurrentCharacterToken(nextLocation: Location | null): void {
@@ -969,8 +975,6 @@ export class Tokenizer {
     // Data state
     //------------------------------------------------------------------
     private _stateData(cp: number): void {
-        this.preprocessor.dropParsedChunk();
-
         switch (cp) {
             case $.LESS_THAN_SIGN: {
                 this.state = State.TAG_OPEN;
@@ -999,8 +1003,6 @@ export class Tokenizer {
     //  RCDATA state
     //------------------------------------------------------------------
     private _stateRcdata(cp: number): void {
-        this.preprocessor.dropParsedChunk();
-
         switch (cp) {
             case $.AMPERSAND: {
                 this.returnState = State.RCDATA;
@@ -1029,8 +1031,6 @@ export class Tokenizer {
     // RAWTEXT state
     //------------------------------------------------------------------
     private _stateRawtext(cp: number): void {
-        this.preprocessor.dropParsedChunk();
-
         switch (cp) {
             case $.LESS_THAN_SIGN: {
                 this.state = State.RAWTEXT_LESS_THAN_SIGN;
@@ -1054,8 +1054,6 @@ export class Tokenizer {
     // Script data state
     //------------------------------------------------------------------
     private _stateScriptData(cp: number): void {
-        this.preprocessor.dropParsedChunk();
-
         switch (cp) {
             case $.LESS_THAN_SIGN: {
                 this.state = State.SCRIPT_DATA_LESS_THAN_SIGN;
@@ -1079,8 +1077,6 @@ export class Tokenizer {
     // PLAINTEXT state
     //------------------------------------------------------------------
     private _statePlaintext(cp: number): void {
-        this.preprocessor.dropParsedChunk();
-
         switch (cp) {
             case $.NULL: {
                 this._err(ERR.unexpectedNullCharacter);

--- a/packages/parse5/lib/tokenizer/preprocessor.ts
+++ b/packages/parse5/lib/tokenizer/preprocessor.ts
@@ -97,8 +97,12 @@ export class Preprocessor {
         return cp;
     }
 
+    public willDropParsedChunk(): boolean {
+        return this.pos > this.bufferWaterline;
+    }
+
     public dropParsedChunk(): void {
-        if (this.pos > this.bufferWaterline) {
+        if (this.willDropParsedChunk()) {
             this.html = this.html.substring(this.pos);
             this.lineStartPos -= this.pos;
             this.droppedBufferSize += this.pos;


### PR DESCRIPTION
Fixes #292, #357

We would sometimes drop chunks before the corresponding tokens were processed by the rewriting stream. This led to #292. Now, we will drop buffers after emitting events.

BREAKING CHANGE: The SAX parser and rewriting stream will now emit text events when the underlying buffer will be dropped right after the event.

@qnighy I've adopted your test from #357 — hope that's okay! I'd also love it if you could make sure this works for you.