### PR TITLE
test(parser): Add location test for script content

### DIFF
--- a/packages/parse5/lib/parser/parser-location-info.test.ts
+++ b/packages/parse5/lib/parser/parser-location-info.test.ts
@@ -152,6 +152,26 @@ generateTestsForEachTreeAdapter('location-info-parser', (treeAdapter) => {
             '<foreignObject></foreignObject>'
         );
     });
+
+    test('Regression - Escaped script content has incorrect location info (GH-265)', () => {
+        const html = '<script>"<!--";</script>';
+
+        const opts = {
+            treeAdapter,
+            sourceCodeLocationInfo: true,
+        };
+
+        const fragment = parse5.parseFragment(html, opts);
+        const script = treeAdapter.getChildNodes(fragment)[0];
+        const location = treeAdapter.getNodeSourceCodeLocation(script);
+        const textLocation = treeAdapter.getNodeSourceCodeLocation(treeAdapter.getChildNodes(script)[0]);
+
+        assert.ok(location && textLocation);
+        assertNodeLocation(location, html, html, [html]);
+        assertStartTagLocation(location, html, html, [html]);
+
+        assertNodeLocation(textLocation, html.slice(8, 15), html, [html]);
+    });
 });
 
 describe('location-info-parser', () => {


### PR DESCRIPTION
Fixes #265

Turns out #265 has already been fixed. This adds a regression test for it.