### PR TITLE
refactor: Make location info parser tests work

### DIFF
--- a/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
+++ b/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
@@ -104,12 +104,7 @@ export function getTemplateContent(templateElement: Element): Document {
     return templateElement.children[0] as Document;
 }
 
-export function setDocumentType(
-    document: Document,
-    name: string | null,
-    publicId: string | null,
-    systemId: string | null
-): void {
+export function setDocumentType(document: Document, name: string, publicId: string, systemId: string): void {
     const data = doctype.serializeContent(name, publicId, systemId);
     let doctypeNode = document.children.find(
         (node): node is ProcessingInstruction => isDirective(node) && node.name === '!doctype'

--- a/packages/parse5/lib/common/doctype.ts
+++ b/packages/parse5/lib/common/doctype.ts
@@ -140,7 +140,7 @@ export function getDocumentMode(token: DoctypeToken): DOCUMENT_MODE {
     return DOCUMENT_MODE.NO_QUIRKS;
 }
 
-export function serializeContent(name: string | null, publicId: string | null, systemId: string | null): string {
+export function serializeContent(name: string, publicId: string, systemId: string): string {
     let str = '!DOCTYPE ';
 
     if (name) {
@@ -153,7 +153,7 @@ export function serializeContent(name: string | null, publicId: string | null, s
         str += ' SYSTEM';
     }
 
-    if (systemId !== null) {
+    if (systemId) {
         str += ` ${enquoteDoctypeId(systemId)}`;
     }
 

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -146,7 +146,8 @@ function serializeNode<T extends TreeAdapterTypeMap>(node: T['node'], options: I
     } else if (options.treeAdapter.isDocumentTypeNode(node)) {
         return serializeDocumentTypeNode(node, options);
     }
-    throw new Error('Unrecognized node type');
+    // Return an empty string for unknown nodes
+    return '';
 }
 
 function serializeElement<T extends TreeAdapterTypeMap>(node: T['element'], options: InternalOptions<T>): string {

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -139,11 +139,14 @@ function serializeChildNodes<T extends TreeAdapterTypeMap>(
 function serializeNode<T extends TreeAdapterTypeMap>(node: T['node'], options: InternalOptions<T>): string {
     if (options.treeAdapter.isElementNode(node)) {
         return serializeElement(node, options);
-    } else if (options.treeAdapter.isTextNode(node)) {
+    }
+    if (options.treeAdapter.isTextNode(node)) {
         return serializeTextNode(node, options);
-    } else if (options.treeAdapter.isCommentNode(node)) {
+    }
+    if (options.treeAdapter.isCommentNode(node)) {
         return serializeCommentNode(node, options);
-    } else if (options.treeAdapter.isDocumentTypeNode(node)) {
+    }
+    if (options.treeAdapter.isDocumentTypeNode(node)) {
         return serializeDocumentTypeNode(node, options);
     }
     // Return an empty string for unknown nodes

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -106,11 +106,11 @@ export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapter.Defa
  * @param options Serialization options.
  */
 export function serializeOuter<T extends TreeAdapterTypeMap = DefaultTreeAdapter.DefaultTreeAdapterMap>(
-    node: T['element'],
+    node: T['node'],
     options?: SerializerOptions<T>
 ): string {
     const opts = { ...defaultOpts, ...options };
-    return serializeElement(node, opts);
+    return serializeNode(node, opts);
 }
 
 function serializeChildNodes<T extends TreeAdapterTypeMap>(
@@ -129,19 +129,24 @@ function serializeChildNodes<T extends TreeAdapterTypeMap>(
 
     if (childNodes) {
         for (const currentNode of childNodes) {
-            if (options.treeAdapter.isElementNode(currentNode)) {
-                html += serializeElement(currentNode, options);
-            } else if (options.treeAdapter.isTextNode(currentNode)) {
-                html += serializeTextNode(currentNode, options);
-            } else if (options.treeAdapter.isCommentNode(currentNode)) {
-                html += serializeCommentNode(currentNode, options);
-            } else if (options.treeAdapter.isDocumentTypeNode(currentNode)) {
-                html += serializeDocumentTypeNode(currentNode, options);
-            }
+            html += serializeNode(currentNode, options);
         }
     }
 
     return html;
+}
+
+function serializeNode<T extends TreeAdapterTypeMap>(node: T['node'], options: InternalOptions<T>): string {
+    if (options.treeAdapter.isElementNode(node)) {
+        return serializeElement(node, options);
+    } else if (options.treeAdapter.isTextNode(node)) {
+        return serializeTextNode(node, options);
+    } else if (options.treeAdapter.isCommentNode(node)) {
+        return serializeCommentNode(node, options);
+    } else if (options.treeAdapter.isDocumentTypeNode(node)) {
+        return serializeDocumentTypeNode(node, options);
+    }
+    throw new Error('Unrecognized node type');
 }
 
 function serializeElement<T extends TreeAdapterTypeMap>(node: T['element'], options: InternalOptions<T>): string {


### PR DESCRIPTION
I realised during the original refactor that `generateLocationInfoParserTests` didn't call some of the functions is was supposed to call. Digging into this now, it turned out that it was calling `escapeString` on the input before processing anything. That meant we would receive a single long string with all of the document's content, and only assert a single time that the received string matched the input.

Now, we properly walk the tree (depth first, from the deepest node), and test nodes along the way.

#436 was found during this effort.

Other changes necessary to make this work:
- `serializeOuter` was updated to serialise any kind of node.
- Removed `null` from document type functions (value was never used)
- **BREAKING:** Before, we would always add an empty `SYSTEM` identifier to the data prop of document types of the htmlparser2 adapter. This was removed; ie. `<!DOCTYPE html "">` is now `<!DOCTYPE html>`.