### PR TITLE
docs: Introduce Typedoc

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,25 @@
+name: Deploy to GitHub Pages
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    deploy:
+        name: Deploy to GitHub Pages
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: lts/*
+                  cache: npm
+            - run: npm ci
+            - name: Build docs
+              run: npm run build:docs
+            - name: Deploy
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: docs/build
+                  cname: parse5.js.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
                 "prettier": "^2.5.0",
                 "ts-jest": "^27.1.3",
                 "ts-node": "^10.7.0",
+                "typedoc": "^0.22.13",
                 "typescript": "^4.6.2"
             }
         },
@@ -2908,9 +2909,10 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.1.7",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4066,6 +4068,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
+        },
         "node_modules/kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4364,6 +4372,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4400,6 +4414,18 @@
             "dev": true,
             "dependencies": {
                 "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/marked": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+            "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+            "dev": true,
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/merge-stream": {
@@ -5102,6 +5128,17 @@
                 "node": ">=10"
             }
         },
+        "node_modules/shiki": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+            "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+            "dev": true,
+            "dependencies": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "5.2.0"
+            }
+        },
         "node_modules/signal-exit": {
             "version": "3.0.5",
             "dev": true,
@@ -5605,6 +5642,49 @@
                 "is-typedarray": "^1.0.0"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.22.13",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
+            "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.2.0",
+                "lunr": "^2.3.9",
+                "marked": "^4.0.12",
+                "minimatch": "^5.0.1",
+                "shiki": "^0.10.1"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 12.10.0"
+            },
+            "peerDependencies": {
+                "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+            }
+        },
+        "node_modules/typedoc/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typedoc/node_modules/minimatch": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+            "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/typescript": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
@@ -5678,6 +5758,18 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
+        "node_modules/vscode-textmate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "dev": true
         },
         "node_modules/w3c-hr-time": {
             "version": "1.0.2",
@@ -5901,6 +5993,9 @@
             "license": "MIT",
             "dependencies": {
                 "entities": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-html-rewriting-stream": {
@@ -5909,6 +6004,9 @@
             "dependencies": {
                 "parse5": "^6.0.1",
                 "parse5-sax-parser": "^6.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-htmlparser2-tree-adapter": {
@@ -5917,6 +6015,9 @@
             "dependencies": {
                 "domhandler": "^4.3.0",
                 "parse5": "^6.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-parser-stream": {
@@ -5924,6 +6025,9 @@
             "license": "MIT",
             "dependencies": {
                 "parse5": "^6.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-plain-text-conversion-stream": {
@@ -5932,6 +6036,9 @@
             "dependencies": {
                 "parse5": "^6.0.1",
                 "parse5-parser-stream": "^6.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-sax-parser": {
@@ -5939,6 +6046,9 @@
             "license": "MIT",
             "dependencies": {
                 "parse5": "^6.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-serializer-stream": {
@@ -5946,6 +6056,9 @@
             "license": "MIT",
             "dependencies": {
                 "parse5": "^6.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "test": {
@@ -7970,7 +8083,9 @@
             "dev": true
         },
         "glob": {
-            "version": "7.1.7",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -8814,6 +8929,12 @@
                 "minimist": "^1.2.5"
             }
         },
+        "jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
+        },
         "kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9014,6 +9135,12 @@
                 "yallist": "^4.0.0"
             }
         },
+        "lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9043,6 +9170,12 @@
             "requires": {
                 "tmpl": "1.0.5"
             }
+        },
+        "marked": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+            "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+            "dev": true
         },
         "merge-stream": {
             "version": "2.0.0",
@@ -9533,6 +9666,17 @@
                 "lru-cache": "^6.0.0"
             }
         },
+        "shiki": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+            "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+            "dev": true,
+            "requires": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "5.2.0"
+            }
+        },
         "signal-exit": {
             "version": "3.0.5",
             "dev": true
@@ -9868,6 +10012,39 @@
                 "is-typedarray": "^1.0.0"
             }
         },
+        "typedoc": {
+            "version": "0.22.13",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
+            "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.2.0",
+                "lunr": "^2.3.9",
+                "marked": "^4.0.12",
+                "minimatch": "^5.0.1",
+                "shiki": "^0.10.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+                    "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
         "typescript": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
@@ -9925,6 +10102,18 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
+        "vscode-textmate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "dev": true
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
         "prettier": "^2.5.0",
         "ts-jest": "^27.1.3",
         "ts-node": "^10.7.0",
+        "typedoc": "^0.22.13",
         "typescript": "^4.6.2"
     },
     "scripts": {
         "build": "npm run build:esm && npm run build:cjs",
         "build:esm": "tsc --build packages/* test",
         "build:cjs": "tsc -p packages/parse5/tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > packages/parse5/dist/cjs/package.json",
+        "build:docs": "typedoc .",
         "prettier": "prettier '**/*.{js,ts,md,json,yml}' --loglevel warn",
         "format": "npm run format:es && npm run format:prettier",
         "format:es": "npm run lint:es -- --fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,11 @@
         "declarationMap": true,
         "sourceMap": true
     },
-    "references": [{ "path": "packages/parse5/tsconfig.json" }]
+    "references": [{ "path": "packages/parse5/tsconfig.json" }],
+    "typedocOptions": {
+        "out": "docs/build",
+        "name": "parse5",
+        "readme": "README.md",
+        "entryPointStrategy": "packages"
+    }
 }


### PR DESCRIPTION
The bare minimum to generate docs with Typedoc, and update them on Github Actions. This is needed to have docs again, for eg. #422.

There are quite a few symbols that cannot be resolved right now. Part of the issue is https://github.com/TypeStrong/typedoc/issues/1835, which prevents symbols from being resolved across packages. We also have to expose additional symbols; eg. #301 will be a part of fixing that. All of that will be tackled after this PR.