### PR TITLE
feat(parser): Align foreign content with spec

### DIFF
--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -10,11 +10,27 @@ import { isElementNode } from '../tree-adapters/default.js';
 
 const origParseFragment = Parser.parseFragment;
 
-generateParsingTests('parser', 'Parser', {}, (test, opts) => ({
-    node: test.fragmentContext
-        ? parse5.parseFragment(test.fragmentContext, test.input, opts)
-        : parse5.parse(test.input, opts),
-}));
+generateParsingTests(
+    'parser',
+    'Parser',
+    {
+        expectErrors: [
+            //NOTE: Foreign content behaviour was updated in the HTML spec.
+            //The old test suite still tests the old behaviour.
+            '269.foreign-fragment',
+            '270.foreign-fragment',
+            '307.foreign-fragment',
+            '309.foreign-fragment',
+            '316.foreign-fragment',
+            '317.foreign-fragment',
+        ],
+    },
+    (test, opts) => ({
+        node: test.fragmentContext
+            ? parse5.parseFragment(test.fragmentContext, test.input, opts)
+            : parse5.parse(test.input, opts),
+    })
+);
 
 generateParsingTests(
     'parser upstream',
@@ -22,29 +38,7 @@ generateParsingTests(
     {
         withoutErrors: true,
         suitePath: new URL('../../../../test/data/html5lib-tests/tree-construction', import.meta.url),
-        expectErrors: [
-            '271.foreign-fragment',
-            '272.foreign-fragment',
-            '309.foreign-fragment',
-            '311.foreign-fragment',
-            '318.foreign-fragment',
-            '319.foreign-fragment',
-            '329.foreign-fragment',
-            '330.foreign-fragment',
-            '331.foreign-fragment',
-            '332.foreign-fragment',
-            '333.foreign-fragment',
-            '334.foreign-fragment',
-            '335.foreign-fragment',
-            '336.foreign-fragment',
-            '337.foreign-fragment',
-            '505.search-element',
-            '506.search-element',
-            '1408.tests26',
-            '1409.tests26',
-            '1410.tests26',
-            '1411.tests26',
-        ],
+        expectErrors: ['505.search-element', '506.search-element'],
     },
     (test, opts) => ({
         node: test.fragmentContext

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -3460,14 +3460,18 @@ function characterInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, t
     p.framesetOk = false;
 }
 
+function popUntilIntegrationPoint<T extends TreeAdapterTypeMap>(p: Parser<T>): void {
+    while (
+        p.treeAdapter.getNamespaceURI(p.openElements.current) !== NS.HTML &&
+        !p._isIntegrationPoint(p.openElements.currentTagId, p.openElements.current)
+    ) {
+        p.openElements.pop();
+    }
+}
+
 function startTagInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToken): void {
-    if (foreignContent.causesExit(token) && !p.fragmentContext) {
-        while (
-            p.treeAdapter.getNamespaceURI(p.openElements.current) !== NS.HTML &&
-            !p._isIntegrationPoint(p.openElements.currentTagId, p.openElements.current)
-        ) {
-            p.openElements.pop();
-        }
+    if (foreignContent.causesExit(token)) {
+        popUntilIntegrationPoint(p);
 
         p._startTagOutsideForeignContent(token);
     } else {
@@ -3494,6 +3498,13 @@ function startTagInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, to
 }
 
 function endTagInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToken): void {
+    if (token.tagID === $.P || token.tagID === $.BR) {
+        popUntilIntegrationPoint(p);
+
+        p._endTagOutsideForeignContent(token);
+
+        return;
+    }
     for (let i = p.openElements.stackTop; i > 0; i--) {
         const element = p.openElements.items[i];
 

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -3460,7 +3460,7 @@ function characterInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, t
     p.framesetOk = false;
 }
 
-function popUntilIntegrationPoint<T extends TreeAdapterTypeMap>(p: Parser<T>): void {
+function popUntilHtmlOrIntegrationPoint<T extends TreeAdapterTypeMap>(p: Parser<T>): void {
     while (
         p.treeAdapter.getNamespaceURI(p.openElements.current) !== NS.HTML &&
         !p._isIntegrationPoint(p.openElements.currentTagId, p.openElements.current)
@@ -3471,7 +3471,7 @@ function popUntilIntegrationPoint<T extends TreeAdapterTypeMap>(p: Parser<T>): v
 
 function startTagInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToken): void {
     if (foreignContent.causesExit(token)) {
-        popUntilIntegrationPoint(p);
+        popUntilHtmlOrIntegrationPoint(p);
 
         p._startTagOutsideForeignContent(token);
     } else {
@@ -3499,7 +3499,7 @@ function startTagInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, to
 
 function endTagInForeignContent<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToken): void {
     if (token.tagID === $.P || token.tagID === $.BR) {
-        popUntilIntegrationPoint(p);
+        popUntilHtmlOrIntegrationPoint(p);
 
         p._endTagOutsideForeignContent(token);
 


### PR DESCRIPTION
The behaviour for parsing foreign content was updated in https://github.com/whatwg/html/pull/6455, https://github.com/whatwg/html/pull/6399, and https://github.com/whatwg/html/pull/6736. This catches us up to the current specced behaviour.