### PR TITLE
fix(package): Allow deep imports from `parse5`

### DIFF
--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -33,8 +33,12 @@
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
-            "import": "dist/index.js",
-            "require": "dist/cjs/index.js"
+            "import": "./dist/index.js",
+            "require": "./dist/cjs/index.js"
+        },
+        "./dist/*": {
+            "import": "./dist/*",
+            "require": "./dist/cjs/*"
         }
     },
     "repository": {


### PR DESCRIPTION
The `generate-parser-feedback-test` script currently fails due to deep imports from `parse5` not being allowed. I assume this will apply to all submodules that currently have deep imports.

For now, let's allow deep imports of all files within `parse5`.