### PR TITLE
refactor: Remove `getNextToken` method

### DIFF
--- a/packages/parse5-parser-stream/lib/index.ts
+++ b/packages/parse5-parser-stream/lib/index.ts
@@ -44,11 +44,11 @@ export class ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> 
         super({ decodeStrings: false });
 
         const resume = (): void => {
-            while (this.pendingHtmlInsertions.length > 0) {
-                const html = this.pendingHtmlInsertions.pop()!;
-
-                this.parser.tokenizer.insertHtmlAtCurrentPos(html);
+            for (let i = this.pendingHtmlInsertions.length - 1; i >= 0; i--) {
+                this.parser.tokenizer.insertHtmlAtCurrentPos(this.pendingHtmlInsertions[i]);
             }
+
+            this.pendingHtmlInsertions.length = 0;
 
             //NOTE: keep parsing if we don't wait for the next input chunk
             this.parser.tokenizer.resume(this.writeCallback);

--- a/packages/parse5-parser-stream/lib/index.ts
+++ b/packages/parse5-parser-stream/lib/index.ts
@@ -3,6 +3,8 @@ import { Parser, ParserOptions } from 'parse5/dist/parser/index.js';
 import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
 import type { DefaultTreeAdapterMap } from 'parse5/dist/tree-adapters/default.js';
 
+/* eslint-disable unicorn/consistent-function-scoping -- The rule seems to be broken here. */
+
 /**
  * Streaming HTML parser with scripting support.
  * A [writable stream](https://nodejs.org/api/stream.html#stream_class_stream_writable).
@@ -28,8 +30,7 @@ import type { DefaultTreeAdapterMap } from 'parse5/dist/tree-adapters/default.js
  */
 export class ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> extends Writable {
     private lastChunkWritten = false;
-    private writeCallback: null | (() => void) = null;
-    private pausedByScript = false;
+    private writeCallback: undefined | (() => void) = undefined;
 
     public parser: Parser<T>;
     private pendingHtmlInsertions: string[] = [];
@@ -42,7 +43,31 @@ export class ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> 
     constructor(options?: ParserOptions<T>) {
         super({ decodeStrings: false });
 
-        this.parser = new Parser(options);
+        const resume = (): void => {
+            while (this.pendingHtmlInsertions.length > 0) {
+                const html = this.pendingHtmlInsertions.pop()!;
+
+                this.parser.tokenizer.insertHtmlAtCurrentPos(html);
+            }
+
+            //NOTE: keep parsing if we don't wait for the next input chunk
+            this.parser.tokenizer.resume(this.writeCallback);
+        };
+
+        const documentWrite = (html: string): void => {
+            if (!this.parser.stopped) {
+                this.pendingHtmlInsertions.push(html);
+            }
+        };
+
+        const scriptHandler = (scriptElement: T['element']): void => {
+            if (this.listenerCount('script') > 0) {
+                this.parser.tokenizer.pause();
+                this.emit('script', scriptElement, documentWrite, resume);
+            }
+        };
+
+        this.parser = new Parser(options, undefined, undefined, scriptHandler);
         this.document = this.parser.document;
     }
 
@@ -53,8 +78,7 @@ export class ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> 
         }
 
         this.writeCallback = callback;
-        this.parser.tokenizer.write(chunk, this.lastChunkWritten);
-        this._runParsingLoop();
+        this.parser.tokenizer.write(chunk, this.lastChunkWritten, this.writeCallback);
     }
 
     // TODO [engine:node@>=16]: Due to issues with Node < 16, we are overriding `end` instead of `_final`.
@@ -64,45 +88,6 @@ export class ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> 
         this.lastChunkWritten = true;
         super.end(chunk || '', encoding, callback);
     }
-
-    //Scriptable parser implementation
-    private _runParsingLoop(): void {
-        this.parser.runParsingLoopForCurrentChunk(this.writeCallback, this._scriptHandler);
-    }
-
-    private _resume = (): void => {
-        if (!this.pausedByScript) {
-            throw new Error('Parser was already resumed');
-        }
-
-        while (this.pendingHtmlInsertions.length > 0) {
-            const html = this.pendingHtmlInsertions.pop()!;
-
-            this.parser.tokenizer.insertHtmlAtCurrentPos(html);
-        }
-
-        this.pausedByScript = false;
-
-        //NOTE: keep parsing if we don't wait for the next input chunk
-        if (this.parser.tokenizer.active) {
-            this._runParsingLoop();
-        }
-    };
-
-    private _documentWrite = (html: string): void => {
-        if (!this.parser.stopped) {
-            this.pendingHtmlInsertions.push(html);
-        }
-    };
-
-    private _scriptHandler = (scriptElement: T['element']): void => {
-        if (this.listenerCount('script') > 0) {
-            this.pausedByScript = true;
-            this.emit('script', scriptElement, this._documentWrite, this._resume);
-        } else {
-            this._runParsingLoop();
-        }
-    };
 }
 
 export interface ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap> {

--- a/packages/parse5-sax-parser/lib/index.ts
+++ b/packages/parse5-sax-parser/lib/index.ts
@@ -123,21 +123,15 @@ export class SAXParser extends Transform implements TokenHandler {
      */
     public stop(): void {
         this.stopped = true;
+        this.tokenizer.pause();
     }
 
     //Internals
     protected _transformChunk(chunk: string): string {
         if (!this.stopped) {
             this.tokenizer.write(chunk, this.lastChunkWritten);
-            this._runParsingLoop();
         }
         return chunk;
-    }
-
-    private _runParsingLoop(): void {
-        while (!this.stopped && this.tokenizer.active) {
-            this.tokenizer.getNextToken();
-        }
     }
 
     /** @internal */

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -305,6 +305,7 @@ export class Tokenizer {
 
         this.paused = false;
 
+        // Necessary for synchronous resume.
         if (this.inLoop) return;
 
         this._runParsingLoop();

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -223,8 +223,9 @@ export interface TokenHandler {
 export class Tokenizer {
     public preprocessor: Preprocessor;
 
-    /** Indicates that the next token has been emitted, and `getNextToken` should return. */
-    private hasEmitted = false;
+    private paused = false;
+    /** Ensures that the parsing loop isn't run multiple times at once. */
+    private inLoop = false;
 
     /**
      * Indicates that the current adjusted node exists, is not an element in the HTML namespace,
@@ -274,10 +275,12 @@ export class Tokenizer {
         };
     }
 
-    //API
-    public getNextToken(): void {
-        this.hasEmitted = false;
-        while (!this.hasEmitted && this.active) {
+    private _runParsingLoop(): void {
+        if (this.inLoop) return;
+
+        this.inLoop = true;
+
+        while (this.active && !this.paused) {
             this.consumedAfterSnapshot = 0;
 
             const cp = this._consume();
@@ -286,16 +289,45 @@ export class Tokenizer {
                 this._callState(cp);
             }
         }
+
+        this.inLoop = false;
     }
 
-    public write(chunk: string, isLastChunk: boolean): void {
+    //API
+    public pause(): void {
+        this.paused = true;
+    }
+
+    public resume(writeCallback?: () => void): void {
+        if (!this.paused) {
+            throw new Error('Parser was already resumed');
+        }
+
+        this.paused = false;
+
+        if (this.inLoop) return;
+
+        this._runParsingLoop();
+
+        if (!this.paused) {
+            writeCallback?.();
+        }
+    }
+
+    public write(chunk: string, isLastChunk: boolean, writeCallback?: () => void): void {
         this.active = true;
         this.preprocessor.write(chunk, isLastChunk);
+        this._runParsingLoop();
+
+        if (!this.paused) {
+            writeCallback?.();
+        }
     }
 
     public insertHtmlAtCurrentPos(chunk: string): void {
         this.active = true;
         this.preprocessor.insertHtmlAtCurrentPos(chunk);
+        this._runParsingLoop();
     }
 
     //Hibernation
@@ -440,7 +472,6 @@ export class Tokenizer {
             ct.location.endOffset = this.preprocessor.offset + 1;
         }
 
-        this.hasEmitted = true;
         this.currentLocation = this.getCurrentLocation(-1);
     }
 
@@ -508,7 +539,6 @@ export class Tokenizer {
                 }
             }
 
-            this.hasEmitted = true;
             this.currentCharacterToken = null;
         }
     }
@@ -524,7 +554,7 @@ export class Tokenizer {
 
         this._emitCurrentCharacterToken(location);
         this.handler.onEof({ type: TokenType.EOF, location });
-        this.hasEmitted = true;
+        this.active = false;
     }
 
     //Characters emission

--- a/test/utils/generate-tokenization-tests.ts
+++ b/test/utils/generate-tokenization-tests.ts
@@ -113,6 +113,7 @@ function tokenize(createTokenSource: TokenSourceCreator, chunks: string[], testD
     }
 
     assert.ok(result.sawEof);
+    assert.ok(!tokenizer.active);
 
     // Sort errors by line and column
     result.errors.sort((err1, err2) => err1.line - err2.line || err1.col - err2.col);

--- a/test/utils/generate-tokenization-tests.ts
+++ b/test/utils/generate-tokenization-tests.ts
@@ -95,14 +95,9 @@ class TokenizeHandler implements TokenSourceData, TokenHandler {
     public errors: TokenError[] = [];
 }
 
-function tokenize(
-    createTokenSource: TokenSourceCreator,
-    chunks: string | string[],
-    testData: LoadedTest
-): TokenSourceData {
+function tokenize(createTokenSource: TokenSourceCreator, chunks: string[], testData: LoadedTest): TokenSourceData {
     const result = new TokenizeHandler(testData);
     const tokenizer = createTokenSource(result);
-    let chunkIdx = 0;
 
     // NOTE: set small waterline for testing purposes
     tokenizer.preprocessor.bufferWaterline = 8;
@@ -112,13 +107,12 @@ function tokenize(
         tokenizer.lastStartTagName = testData.lastStartTag;
     }
 
-    while (!result.sawEof) {
-        if (tokenizer.active) {
-            tokenizer.getNextToken();
-        } else {
-            tokenizer.write(chunks[chunkIdx], ++chunkIdx === chunks.length);
-        }
+    for (let i = 0; i < chunks.length; i++) {
+        assert.ok(!result.sawEof);
+        tokenizer.write(chunks[i], i === chunks.length - 1);
     }
+
+    assert.ok(result.sawEof);
 
     // Sort errors by line and column
     result.errors.sort((err1, err2) => err1.line - err2.line || err1.col - err2.col);


### PR DESCRIPTION
Removes the `getNextToken` function of the tokenizer, as well as all parsing loops. `getNextToken` was already a bit of a misnomer, as it would emit tokens to token handlers instead of returning it to the caller. Turns out parsing loops aren't necessary anymore, so let's get rid of them.

Script handling had to be updated slightly to support this. Now, a script handler is supplied to the parser constructor, and will be called whenever a script is encountered. This simplifies script handling logic in a few places.