### PR TITLE
chore(docs): Increase Node memory limit for docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,5 @@ test/data/html5lib-tests
 test/data/html5lib-tests-fork
 packages/*/dist/
 test/dist/
+docs/build/
 node_modules

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "build": "npm run build:esm && npm run build:cjs",
         "build:esm": "tsc --build packages/* test",
         "build:cjs": "tsc -p packages/parse5/tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > packages/parse5/dist/cjs/package.json",
-        "build:docs": "typedoc .",
+        "build:docs": "node --max-old-space-size=8192 node_modules/.bin/typedoc .",
         "prettier": "prettier '**/*.{js,ts,md,json,yml}' --loglevel warn",
         "format": "npm run format:es && npm run format:prettier",
         "format:es": "npm run lint:es -- --fix",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,8 @@
         "out": "docs/build",
         "name": "parse5",
         "readme": "README.md",
+        "emit": "docs",
+        "excludeInternal": true,
         "entryPointStrategy": "packages"
     }
 }


### PR DESCRIPTION
`typedoc` builds successfully on my local ARM Mac, but runs out of memory on GitHub Actions. I suspect that the limit needs to be bumped slightly to make things go for now.

This is a known issue: https://github.com/TypeStrong/typedoc/issues/1606

This PR also includes a config change of typedoc to stop emitting source code, and to exclude functions marked as `@internal`. Plus, ESLint will now ignore built docs.