### PR TITLE
fix(htmlparser2-adapter): Use domhandler@4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,8 +2186,9 @@
             }
         },
         "node_modules/domhandler": {
-            "version": "4.3.0",
-            "license": "BSD-2-Clause",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "dependencies": {
                 "domelementtype": "^2.2.0"
             },
@@ -6004,7 +6005,7 @@
             "version": "6.0.1",
             "license": "MIT",
             "dependencies": {
-                "domhandler": "^4.3.0",
+                "domhandler": "^4.3.1",
                 "parse5": "^6.0.1"
             },
             "funding": {
@@ -7578,7 +7579,9 @@
             }
         },
         "domhandler": {
-            "version": "4.3.0",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
             "requires": {
                 "domelementtype": "^2.2.0"
             }
@@ -9354,7 +9357,7 @@
         "parse5-htmlparser2-tree-adapter": {
             "version": "file:packages/parse5-htmlparser2-tree-adapter",
             "requires": {
-                "domhandler": "^4.3.0",
+                "domhandler": "4.3.1",
                 "parse5": "^6.0.1"
             }
         },

--- a/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
+++ b/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
@@ -242,20 +242,18 @@ export function setNodeSourceCodeLocation(node: Node, location: ElementLocation 
         node.endIndex = location.endOffset;
     }
 
-    // TODO: Update types in `domhandler`
-    node.sourceCodeLocation = location as any;
+    node.sourceCodeLocation = location;
 }
 
 export function getNodeSourceCodeLocation(node: Node): ElementLocation | null | undefined {
-    return node.sourceCodeLocation as ElementLocation | null | undefined;
+    return node.sourceCodeLocation;
 }
 
-export function updateNodeSourceCodeLocation(node: Node, endLocation: Partial<ElementLocation>): void {
+export function updateNodeSourceCodeLocation(node: Node, endLocation: ElementLocation): void {
     if (endLocation.endOffset != null) node.endIndex = endLocation.endOffset;
 
-    // TODO: Update types in `domhandler`
     node.sourceCodeLocation = {
         ...node.sourceCodeLocation,
         ...endLocation,
-    } as any;
+    };
 }

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -16,7 +16,7 @@
     "license": "MIT",
     "main": "dist/index.js",
     "dependencies": {
-        "domhandler": "^4.3.0",
+        "domhandler": "^4.3.1",
         "parse5": "^6.0.1"
     },
     "repository": {


### PR DESCRIPTION
The new version includes fixed location types. Removed all casts that were necessary to make this work before.