### PR TITLE
chore: Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Exclude the HTML files from GitHub's language statistics
 # https://github.com/github/linguist#using-gitattributes
-packages/test-utils/data/* linguist-vendored
+test/data/* linguist-vendored


### PR DESCRIPTION
This will make GitHub's language statistics ignore all test files.