### PR TITLE
refactor: Use objects for adapters

### DIFF
--- a/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
+++ b/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
@@ -1,7 +1,7 @@
 import * as doctype from 'parse5/dist/common/doctype.js';
 import { DOCUMENT_MODE, NAMESPACES as NS } from 'parse5/dist/common/html.js';
 import type { Attribute, ElementLocation } from 'parse5/dist/common/token.js';
-import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
+import type { TreeAdapter, TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
 import {
     Node,
     NodeWithChildren,
@@ -12,8 +12,9 @@ import {
     Text,
     isDirective,
     isText,
+    isComment,
+    isTag,
 } from 'domhandler';
-export { isComment as isCommentNode, isTag as isElementNode, isText as isTextNode } from 'domhandler';
 
 export type Htmlparser2TreeAdapterMap = TreeAdapterTypeMap<
     Node,
@@ -28,232 +29,239 @@ export type Htmlparser2TreeAdapterMap = TreeAdapterTypeMap<
     ProcessingInstruction
 >;
 
-//Node construction
-export function createDocument(): Document {
-    const node = new Document([]);
-    node['x-mode'] = DOCUMENT_MODE.NO_QUIRKS;
-    return node;
-}
-
-export function createDocumentFragment(): Document {
-    return new Document([]);
-}
-
-export function createElement(tagName: string, namespaceURI: NS, attrs: Attribute[]): Element {
-    const attribs = Object.create(null);
-    const attribsNamespace = Object.create(null);
-    const attribsPrefix = Object.create(null);
-
-    for (let i = 0; i < attrs.length; i++) {
-        const attrName = attrs[i].name;
-
-        attribs[attrName] = attrs[i].value;
-        attribsNamespace[attrName] = attrs[i].namespace;
-        attribsPrefix[attrName] = attrs[i].prefix;
-    }
-
-    const node = new Element(tagName, attribs, []);
-    node.namespace = namespaceURI;
-    node['x-attribsNamespace'] = attribsNamespace;
-    node['x-attribsPrefix'] = attribsPrefix;
-    return node;
-}
-
-export function createCommentNode(data: string): Comment {
-    return new Comment(data);
-}
-
 function createTextNode(value: string): Text {
     return new Text(value);
 }
 
-//Tree mutation
-export function appendChild(parentNode: NodeWithChildren, newNode: Node): void {
-    const prev = parentNode.children[parentNode.children.length - 1];
+export const adapter: TreeAdapter<Htmlparser2TreeAdapterMap> = {
+    // Re-exports from domhandler
+    isCommentNode: isComment,
+    isElementNode: isTag,
+    isTextNode: isText,
 
-    if (prev) {
-        prev.next = newNode;
-        newNode.prev = prev;
-    }
+    //Node construction
+    createDocument(): Document {
+        const node = new Document([]);
+        node['x-mode'] = DOCUMENT_MODE.NO_QUIRKS;
+        return node;
+    },
 
-    parentNode.children.push(newNode);
-    newNode.parent = parentNode;
-}
+    createDocumentFragment(): Document {
+        return new Document([]);
+    },
 
-export function insertBefore(parentNode: NodeWithChildren, newNode: Node, referenceNode: Node): void {
-    const insertionIdx = parentNode.children.indexOf(referenceNode);
-    const { prev } = referenceNode;
+    createElement(tagName: string, namespaceURI: NS, attrs: Attribute[]): Element {
+        const attribs = Object.create(null);
+        const attribsNamespace = Object.create(null);
+        const attribsPrefix = Object.create(null);
 
-    if (prev) {
-        prev.next = newNode;
-        newNode.prev = prev;
-    }
+        for (let i = 0; i < attrs.length; i++) {
+            const attrName = attrs[i].name;
 
-    referenceNode.prev = newNode;
-    newNode.next = referenceNode;
+            attribs[attrName] = attrs[i].value;
+            attribsNamespace[attrName] = attrs[i].namespace;
+            attribsPrefix[attrName] = attrs[i].prefix;
+        }
 
-    parentNode.children.splice(insertionIdx, 0, newNode);
-    newNode.parent = parentNode;
-}
+        const node = new Element(tagName, attribs, []);
+        node.namespace = namespaceURI;
+        node['x-attribsNamespace'] = attribsNamespace;
+        node['x-attribsPrefix'] = attribsPrefix;
+        return node;
+    },
 
-export function setTemplateContent(templateElement: Element, contentElement: Document): void {
-    appendChild(templateElement, contentElement);
-}
+    createCommentNode(data: string): Comment {
+        return new Comment(data);
+    },
 
-export function getTemplateContent(templateElement: Element): Document {
-    return templateElement.children[0] as Document;
-}
-
-export function setDocumentType(document: Document, name: string, publicId: string, systemId: string): void {
-    const data = doctype.serializeContent(name, publicId, systemId);
-    let doctypeNode = document.children.find(
-        (node): node is ProcessingInstruction => isDirective(node) && node.name === '!doctype'
-    );
-
-    if (doctypeNode) {
-        doctypeNode.data = data ?? null;
-    } else {
-        doctypeNode = new ProcessingInstruction('!doctype', data);
-        appendChild(document, doctypeNode);
-    }
-
-    doctypeNode['x-name'] = name ?? undefined;
-    doctypeNode['x-publicId'] = publicId ?? undefined;
-    doctypeNode['x-systemId'] = systemId ?? undefined;
-}
-
-export function setDocumentMode(document: Document, mode: DOCUMENT_MODE): void {
-    document['x-mode'] = mode;
-}
-
-export function getDocumentMode(document: Document): DOCUMENT_MODE {
-    return document['x-mode'] as DOCUMENT_MODE;
-}
-
-export function detachNode(node: Node): void {
-    if (node.parent) {
-        const idx = node.parent.children.indexOf(node);
-        const { prev, next } = node;
-
-        node.prev = null;
-        node.next = null;
+    //Tree mutation
+    appendChild(parentNode: NodeWithChildren, newNode: Node): void {
+        const prev = parentNode.children[parentNode.children.length - 1];
 
         if (prev) {
-            prev.next = next;
+            prev.next = newNode;
+            newNode.prev = prev;
         }
 
-        if (next) {
-            next.prev = prev;
+        parentNode.children.push(newNode);
+        newNode.parent = parentNode;
+    },
+
+    insertBefore(parentNode: NodeWithChildren, newNode: Node, referenceNode: Node): void {
+        const insertionIdx = parentNode.children.indexOf(referenceNode);
+        const { prev } = referenceNode;
+
+        if (prev) {
+            prev.next = newNode;
+            newNode.prev = prev;
         }
 
-        node.parent.children.splice(idx, 1);
-        node.parent = null;
-    }
-}
+        referenceNode.prev = newNode;
+        newNode.next = referenceNode;
 
-export function insertText(parentNode: NodeWithChildren, text: string): void {
-    const lastChild = parentNode.children[parentNode.children.length - 1];
+        parentNode.children.splice(insertionIdx, 0, newNode);
+        newNode.parent = parentNode;
+    },
 
-    if (lastChild && isText(lastChild)) {
-        lastChild.data += text;
-    } else {
-        appendChild(parentNode, createTextNode(text));
-    }
-}
+    setTemplateContent(templateElement: Element, contentElement: Document): void {
+        adapter.appendChild(templateElement, contentElement);
+    },
 
-export function insertTextBefore(parentNode: NodeWithChildren, text: string, referenceNode: Node): void {
-    const prevNode = parentNode.children[parentNode.children.indexOf(referenceNode) - 1];
+    getTemplateContent(templateElement: Element): Document {
+        return templateElement.children[0] as Document;
+    },
 
-    if (prevNode && isText(prevNode)) {
-        prevNode.data += text;
-    } else {
-        insertBefore(parentNode, createTextNode(text), referenceNode);
-    }
-}
+    setDocumentType(document: Document, name: string, publicId: string, systemId: string): void {
+        const data = doctype.serializeContent(name, publicId, systemId);
+        let doctypeNode = document.children.find(
+            (node): node is ProcessingInstruction => isDirective(node) && node.name === '!doctype'
+        );
 
-export function adoptAttributes(recipient: Element, attrs: Attribute[]): void {
-    for (let i = 0; i < attrs.length; i++) {
-        const attrName = attrs[i].name;
-
-        if (typeof recipient.attribs[attrName] === 'undefined') {
-            recipient.attribs[attrName] = attrs[i].value;
-            recipient['x-attribsNamespace']![attrName] = attrs[i].namespace!;
-            recipient['x-attribsPrefix']![attrName] = attrs[i].prefix!;
+        if (doctypeNode) {
+            doctypeNode.data = data ?? null;
+        } else {
+            doctypeNode = new ProcessingInstruction('!doctype', data);
+            adapter.appendChild(document, doctypeNode);
         }
-    }
-}
 
-//Tree traversing
-export function getFirstChild(node: NodeWithChildren): Node | null {
-    return node.children[0];
-}
+        doctypeNode['x-name'] = name ?? undefined;
+        doctypeNode['x-publicId'] = publicId ?? undefined;
+        doctypeNode['x-systemId'] = systemId ?? undefined;
+    },
 
-export function getChildNodes(node: NodeWithChildren): Node[] {
-    return node.children;
-}
+    setDocumentMode(document: Document, mode: DOCUMENT_MODE): void {
+        document['x-mode'] = mode;
+    },
 
-export function getParentNode(node: Node): NodeWithChildren | null {
-    return node.parent;
-}
+    getDocumentMode(document: Document): DOCUMENT_MODE {
+        return document['x-mode'] as DOCUMENT_MODE;
+    },
 
-export function getAttrList(element: Element): Attribute[] {
-    return element.attributes;
-}
+    detachNode(node: Node): void {
+        if (node.parent) {
+            const idx = node.parent.children.indexOf(node);
+            const { prev, next } = node;
 
-//Node data
-export function getTagName(element: Element): string {
-    return element.name;
-}
+            node.prev = null;
+            node.next = null;
 
-export function getNamespaceURI(element: Element): NS {
-    return element.namespace as NS;
-}
+            if (prev) {
+                prev.next = next;
+            }
 
-export function getTextNodeContent(textNode: Text): string {
-    return textNode.data;
-}
+            if (next) {
+                next.prev = prev;
+            }
 
-export function getCommentNodeContent(commentNode: Comment): string {
-    return commentNode.data;
-}
+            node.parent.children.splice(idx, 1);
+            node.parent = null;
+        }
+    },
 
-export function getDocumentTypeNodeName(doctypeNode: ProcessingInstruction): string {
-    return doctypeNode['x-name'] ?? '';
-}
+    insertText(parentNode: NodeWithChildren, text: string): void {
+        const lastChild = parentNode.children[parentNode.children.length - 1];
 
-export function getDocumentTypeNodePublicId(doctypeNode: ProcessingInstruction): string {
-    return doctypeNode['x-publicId'] ?? '';
-}
+        if (lastChild && isText(lastChild)) {
+            lastChild.data += text;
+        } else {
+            adapter.appendChild(parentNode, createTextNode(text));
+        }
+    },
 
-export function getDocumentTypeNodeSystemId(doctypeNode: ProcessingInstruction): string {
-    return doctypeNode['x-systemId'] ?? '';
-}
+    insertTextBefore(parentNode: NodeWithChildren, text: string, referenceNode: Node): void {
+        const prevNode = parentNode.children[parentNode.children.indexOf(referenceNode) - 1];
 
-//Node types
+        if (prevNode && isText(prevNode)) {
+            prevNode.data += text;
+        } else {
+            adapter.insertBefore(parentNode, createTextNode(text), referenceNode);
+        }
+    },
 
-export function isDocumentTypeNode(node: Node): node is ProcessingInstruction {
-    return isDirective(node) && node.name === '!doctype';
-}
+    adoptAttributes(recipient: Element, attrs: Attribute[]): void {
+        for (let i = 0; i < attrs.length; i++) {
+            const attrName = attrs[i].name;
 
-// Source code location
-export function setNodeSourceCodeLocation(node: Node, location: ElementLocation | null): void {
-    if (location) {
-        node.startIndex = location.startOffset;
-        node.endIndex = location.endOffset;
-    }
+            if (typeof recipient.attribs[attrName] === 'undefined') {
+                recipient.attribs[attrName] = attrs[i].value;
+                recipient['x-attribsNamespace']![attrName] = attrs[i].namespace!;
+                recipient['x-attribsPrefix']![attrName] = attrs[i].prefix!;
+            }
+        }
+    },
 
-    node.sourceCodeLocation = location;
-}
+    //Tree traversing
+    getFirstChild(node: NodeWithChildren): Node | null {
+        return node.children[0];
+    },
 
-export function getNodeSourceCodeLocation(node: Node): ElementLocation | null | undefined {
-    return node.sourceCodeLocation;
-}
+    getChildNodes(node: NodeWithChildren): Node[] {
+        return node.children;
+    },
 
-export function updateNodeSourceCodeLocation(node: Node, endLocation: ElementLocation): void {
-    if (endLocation.endOffset != null) node.endIndex = endLocation.endOffset;
+    getParentNode(node: Node): NodeWithChildren | null {
+        return node.parent;
+    },
 
-    node.sourceCodeLocation = {
-        ...node.sourceCodeLocation,
-        ...endLocation,
-    };
-}
+    getAttrList(element: Element): Attribute[] {
+        return element.attributes;
+    },
+
+    //Node data
+    getTagName(element: Element): string {
+        return element.name;
+    },
+
+    getNamespaceURI(element: Element): NS {
+        return element.namespace as NS;
+    },
+
+    getTextNodeContent(textNode: Text): string {
+        return textNode.data;
+    },
+
+    getCommentNodeContent(commentNode: Comment): string {
+        return commentNode.data;
+    },
+
+    getDocumentTypeNodeName(doctypeNode: ProcessingInstruction): string {
+        return doctypeNode['x-name'] ?? '';
+    },
+
+    getDocumentTypeNodePublicId(doctypeNode: ProcessingInstruction): string {
+        return doctypeNode['x-publicId'] ?? '';
+    },
+
+    getDocumentTypeNodeSystemId(doctypeNode: ProcessingInstruction): string {
+        return doctypeNode['x-systemId'] ?? '';
+    },
+
+    //Node types
+
+    isDocumentTypeNode(node: Node): node is ProcessingInstruction {
+        return isDirective(node) && node.name === '!doctype';
+    },
+
+    // Source code location
+    setNodeSourceCodeLocation(node: Node, location: ElementLocation | null): void {
+        if (location) {
+            node.startIndex = location.startOffset;
+            node.endIndex = location.endOffset;
+        }
+
+        node.sourceCodeLocation = location;
+    },
+
+    getNodeSourceCodeLocation(node: Node): ElementLocation | null | undefined {
+        return node.sourceCodeLocation;
+    },
+
+    updateNodeSourceCodeLocation(node: Node, endLocation: ElementLocation): void {
+        if (endLocation.endOffset != null) node.endIndex = endLocation.endOffset;
+
+        node.sourceCodeLocation = {
+            ...node.sourceCodeLocation,
+            ...endLocation,
+        };
+    },
+};

--- a/packages/parse5-parser-stream/test/utils/parse-chunked.ts
+++ b/packages/parse5-parser-stream/test/utils/parse-chunked.ts
@@ -1,4 +1,4 @@
-import type { ParserOptions } from 'parse5/dist/parser/index.js';
+import type { ParserOptions } from 'parse5';
 import type { TreeAdapterTypeMap } from 'parse5/dist/tree-adapters/interface.js';
 import { ParserStream } from '../../lib/index.js';
 import { makeChunks } from 'parse5-test-utils/utils/common.js';

--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -6,7 +6,6 @@ import type { TreeAdapterTypeMap } from './../tree-adapters/interface.js';
 import { generateParsingTests } from 'parse5-test-utils/utils/generate-parsing-tests.js';
 import { treeAdapters } from 'parse5-test-utils/utils/common.js';
 import { NAMESPACES as NS } from '../common/html.js';
-import { isElementNode } from '../tree-adapters/default.js';
 
 const origParseFragment = Parser.parseFragment;
 
@@ -149,9 +148,9 @@ describe('parser', () => {
             });
 
             const htmlElement = document.childNodes[0];
-            assert.ok(isElementNode(htmlElement));
+            assert.ok(treeAdapters.default.isElementNode(htmlElement));
             const bodyElement = htmlElement.childNodes[1];
-            assert.ok(isElementNode(bodyElement));
+            assert.ok(treeAdapters.default.isElementNode(bodyElement));
             // Expect 5 opened elements; in order: html, head, body, and 2x p
             expect(onItemPush).toHaveBeenCalledTimes(5);
             expect(onItemPush).toHaveBeenNthCalledWith(1, htmlElement);

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -1,7 +1,7 @@
 import { TokenHandler, Tokenizer, TokenizerMode } from '../tokenizer/index.js';
 import { OpenElementStack, StackHandler } from './open-element-stack.js';
 import { FormattingElementList, ElementEntry, EntryType } from './formatting-element-list.js';
-import * as defaultTreeAdapter from '../tree-adapters/default.js';
+import { defaultTreeAdapter } from '../tree-adapters/default.js';
 import * as doctype from '../common/doctype.js';
 import * as foreignContent from '../common/foreign-content.js';
 import { ERR, ParserErrorHandler } from '../common/error-codes.js';
@@ -111,7 +111,7 @@ export interface ParserOptions<T extends TreeAdapterTypeMap> {
     onParseError?: ParserErrorHandler | null;
 }
 
-const defaultParserOptions = {
+const defaultParserOptions: Required<ParserOptions<any>> = {
     scriptingEnabled: true,
     sourceCodeLocationInfo: false,
     treeAdapter: defaultTreeAdapter,

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -1,7 +1,7 @@
 import { TokenHandler, Tokenizer, TokenizerMode } from '../tokenizer/index.js';
 import { OpenElementStack, StackHandler } from './open-element-stack.js';
 import { FormattingElementList, ElementEntry, EntryType } from './formatting-element-list.js';
-import { defaultTreeAdapter } from '../tree-adapters/default.js';
+import { defaultTreeAdapter, DefaultTreeAdapterMap } from '../tree-adapters/default.js';
 import * as doctype from '../common/doctype.js';
 import * as foreignContent from '../common/foreign-content.js';
 import { ERR, ParserErrorHandler } from '../common/error-codes.js';
@@ -111,7 +111,7 @@ export interface ParserOptions<T extends TreeAdapterTypeMap> {
     onParseError?: ParserErrorHandler | null;
 }
 
-const defaultParserOptions: Required<ParserOptions<any>> = {
+const defaultParserOptions: Required<ParserOptions<DefaultTreeAdapterMap>> = {
     scriptingEnabled: true,
     sourceCodeLocationInfo: false,
     treeAdapter: defaultTreeAdapter,
@@ -135,7 +135,7 @@ export class Parser<T extends TreeAdapterTypeMap> implements TokenHandler, Stack
         this.options = {
             ...defaultParserOptions,
             ...options,
-        };
+        } as Required<ParserOptions<T>>;
 
         this.treeAdapter = this.options.treeAdapter;
         this.onParseError = this.options.onParseError;
@@ -173,7 +173,7 @@ export class Parser<T extends TreeAdapterTypeMap> implements TokenHandler, Stack
         const opts: Required<ParserOptions<T>> = {
             ...defaultParserOptions,
             ...options,
-        };
+        } as Required<ParserOptions<T>>;
 
         //NOTE: use a <template> element as the fragment context if no context element was provided,
         //so we will parse in a "forgiving" manner

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'node:assert';
 import * as parse5 from 'parse5';
 import { generateSerializerTests } from 'parse5-test-utils/utils/generate-serializer-tests.js';
 import { treeAdapters } from 'parse5-test-utils/utils/common.js';
-import { type Element, isElementNode } from 'parse5/dist/tree-adapters/default';
+import { type Element } from 'parse5/dist/tree-adapters/default.js';
 import { NAMESPACES } from 'parse5/dist/common/html.js';
 
 generateSerializerTests('serializer', 'Serializer', parse5.serialize);
@@ -28,7 +28,7 @@ describe('serializer', () => {
         it('serializes outerHTML correctly', () => {
             const document = parse5.parseFragment('<div><button>Hello</button></div>');
             const div = document.childNodes[0];
-            assert.ok(isElementNode(div));
+            assert.ok(treeAdapters.default.isElementNode(div));
             const html = parse5.serializeOuter(div);
 
             assert.equal(html, '<div><button>Hello</button></div>');
@@ -38,7 +38,7 @@ describe('serializer', () => {
     it('serializes <template> elements inner content', () => {
         const document = parse5.parseFragment('<template><button>Hello</button></template>');
         const template = document.childNodes[0];
-        assert.ok(isElementNode(template));
+        assert.ok(treeAdapters.default.isElementNode(template));
         const html = parse5.serialize(template);
 
         assert.equal(html, '<button>Hello</button>');

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -1,6 +1,6 @@
 import { TAG_NAMES as $, NAMESPACES as NS } from '../common/html.js';
 import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface';
-import * as DefaultTreeAdapter from '../tree-adapters/default.js';
+import { defaultTreeAdapter, type DefaultTreeAdapterMap } from '../tree-adapters/default.js';
 
 //Escaping regexes
 const AMP_REGEX = /&/g;
@@ -63,7 +63,7 @@ export interface SerializerOptions<T extends TreeAdapterTypeMap> {
 
 type InternalOptions<T extends TreeAdapterTypeMap> = Required<SerializerOptions<T>>;
 
-const defaultOpts = { treeAdapter: DefaultTreeAdapter, scriptingEnabled: true };
+const defaultOpts: InternalOptions<any> = { treeAdapter: defaultTreeAdapter, scriptingEnabled: true };
 
 /**
  * Serializes an AST node to an HTML string.
@@ -87,7 +87,7 @@ const defaultOpts = { treeAdapter: DefaultTreeAdapter, scriptingEnabled: true };
  * @param node Node to serialize.
  * @param options Serialization options.
  */
-export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapter.DefaultTreeAdapterMap>(
+export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
     node: T['parentNode'],
     options?: SerializerOptions<T>
 ): string {
@@ -119,7 +119,7 @@ export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapter.Defa
  * @param node Node to serialize.
  * @param options Serialization options.
  */
-export function serializeOuter<T extends TreeAdapterTypeMap = DefaultTreeAdapter.DefaultTreeAdapterMap>(
+export function serializeOuter<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
     node: T['node'],
     options?: SerializerOptions<T>
 ): string {

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -63,7 +63,7 @@ export interface SerializerOptions<T extends TreeAdapterTypeMap> {
 
 type InternalOptions<T extends TreeAdapterTypeMap> = Required<SerializerOptions<T>>;
 
-const defaultOpts: InternalOptions<any> = { treeAdapter: defaultTreeAdapter, scriptingEnabled: true };
+const defaultOpts: InternalOptions<DefaultTreeAdapterMap> = { treeAdapter: defaultTreeAdapter, scriptingEnabled: true };
 
 /**
  * Serializes an AST node to an HTML string.
@@ -91,7 +91,7 @@ export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
     node: T['parentNode'],
     options?: SerializerOptions<T>
 ): string {
-    const opts = { ...defaultOpts, ...options };
+    const opts = { ...defaultOpts, ...options } as InternalOptions<T>;
 
     if (isVoidElement(node, opts)) {
         return '';
@@ -123,7 +123,7 @@ export function serializeOuter<T extends TreeAdapterTypeMap = DefaultTreeAdapter
     node: T['node'],
     options?: SerializerOptions<T>
 ): string {
-    const opts = { ...defaultOpts, ...options };
+    const opts = { ...defaultOpts, ...options } as InternalOptions<T>;
     return serializeNode(node, opts);
 }
 

--- a/packages/parse5/lib/tree-adapters/default.ts
+++ b/packages/parse5/lib/tree-adapters/default.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT_MODE, NAMESPACES } from '../common/html.js';
 import type { Attribute, Location, ElementLocation } from '../common/token.js';
-import type { TreeAdapterTypeMap } from './interface.js';
+import type { TreeAdapter, TreeAdapterTypeMap } from './interface.js';
 
 export enum NodeType {
     Document = '#document',
@@ -110,213 +110,215 @@ export type DefaultTreeAdapterMap = TreeAdapterTypeMap<
     DocumentType
 >;
 
-//Node construction
-export function createDocument(): Document {
-    return {
-        nodeName: NodeType.Document,
-        mode: DOCUMENT_MODE.NO_QUIRKS,
-        childNodes: [],
-    };
-}
-
-export function createDocumentFragment(): DocumentFragment {
-    return {
-        nodeName: NodeType.DocumentFragment,
-        childNodes: [],
-    };
-}
-
-export function createElement(tagName: string, namespaceURI: NAMESPACES, attrs: Attribute[]): Element {
-    return {
-        nodeName: tagName,
-        tagName,
-        attrs,
-        namespaceURI,
-        childNodes: [],
-        parentNode: null,
-    };
-}
-
-export function createCommentNode(data: string): CommentNode {
-    return {
-        nodeName: NodeType.Comment,
-        data,
-        parentNode: null,
-    };
-}
-
-const createTextNode = function (value: string): TextNode {
+function createTextNode(value: string): TextNode {
     return {
         nodeName: NodeType.Text,
         value,
         parentNode: null,
     };
-};
-
-//Tree mutation
-export function appendChild(parentNode: ParentNode, newNode: ChildNode): void {
-    parentNode.childNodes.push(newNode);
-    newNode.parentNode = parentNode;
 }
 
-export function insertBefore(parentNode: ParentNode, newNode: ChildNode, referenceNode: ChildNode): void {
-    const insertionIdx = parentNode.childNodes.indexOf(referenceNode);
+export const defaultTreeAdapter: TreeAdapter<DefaultTreeAdapterMap> = {
+    //Node construction
+    createDocument(): Document {
+        return {
+            nodeName: NodeType.Document,
+            mode: DOCUMENT_MODE.NO_QUIRKS,
+            childNodes: [],
+        };
+    },
 
-    parentNode.childNodes.splice(insertionIdx, 0, newNode);
-    newNode.parentNode = parentNode;
-}
+    createDocumentFragment(): DocumentFragment {
+        return {
+            nodeName: NodeType.DocumentFragment,
+            childNodes: [],
+        };
+    },
 
-export function setTemplateContent(templateElement: Template, contentElement: DocumentFragment): void {
-    templateElement.content = contentElement;
-}
-
-export function getTemplateContent(templateElement: Template): DocumentFragment {
-    return templateElement.content;
-}
-
-export function setDocumentType(document: Document, name: string, publicId: string, systemId: string): void {
-    const doctypeNode = document.childNodes.find(
-        (node): node is DocumentType => node.nodeName === NodeType.DocumentType
-    );
-
-    if (doctypeNode) {
-        doctypeNode.name = name;
-        doctypeNode.publicId = publicId;
-        doctypeNode.systemId = systemId;
-    } else {
-        const node: DocumentType = {
-            nodeName: NodeType.DocumentType,
-            name,
-            publicId,
-            systemId,
+    createElement(tagName: string, namespaceURI: NAMESPACES, attrs: Attribute[]): Element {
+        return {
+            nodeName: tagName,
+            tagName,
+            attrs,
+            namespaceURI,
+            childNodes: [],
             parentNode: null,
         };
-        appendChild(document, node);
-    }
-}
+    },
 
-export function setDocumentMode(document: Document, mode: DOCUMENT_MODE): void {
-    document.mode = mode;
-}
+    createCommentNode(data: string): CommentNode {
+        return {
+            nodeName: NodeType.Comment,
+            data,
+            parentNode: null,
+        };
+    },
 
-export function getDocumentMode(document: Document): DOCUMENT_MODE {
-    return document.mode;
-}
+    //Tree mutation
+    appendChild(parentNode: ParentNode, newNode: ChildNode): void {
+        parentNode.childNodes.push(newNode);
+        newNode.parentNode = parentNode;
+    },
 
-export function detachNode(node: ChildNode): void {
-    if (node.parentNode) {
-        const idx = node.parentNode.childNodes.indexOf(node);
+    insertBefore(parentNode: ParentNode, newNode: ChildNode, referenceNode: ChildNode): void {
+        const insertionIdx = parentNode.childNodes.indexOf(referenceNode);
 
-        node.parentNode.childNodes.splice(idx, 1);
-        node.parentNode = null;
-    }
-}
+        parentNode.childNodes.splice(insertionIdx, 0, newNode);
+        newNode.parentNode = parentNode;
+    },
 
-export function insertText(parentNode: ParentNode, text: string): void {
-    if (parentNode.childNodes.length > 0) {
-        const prevNode = parentNode.childNodes[parentNode.childNodes.length - 1];
+    setTemplateContent(templateElement: Template, contentElement: DocumentFragment): void {
+        templateElement.content = contentElement;
+    },
 
-        if (isTextNode(prevNode)) {
+    getTemplateContent(templateElement: Template): DocumentFragment {
+        return templateElement.content;
+    },
+
+    setDocumentType(document: Document, name: string, publicId: string, systemId: string): void {
+        const doctypeNode = document.childNodes.find(
+            (node): node is DocumentType => node.nodeName === NodeType.DocumentType
+        );
+
+        if (doctypeNode) {
+            doctypeNode.name = name;
+            doctypeNode.publicId = publicId;
+            doctypeNode.systemId = systemId;
+        } else {
+            const node: DocumentType = {
+                nodeName: NodeType.DocumentType,
+                name,
+                publicId,
+                systemId,
+                parentNode: null,
+            };
+            defaultTreeAdapter.appendChild(document, node);
+        }
+    },
+
+    setDocumentMode(document: Document, mode: DOCUMENT_MODE): void {
+        document.mode = mode;
+    },
+
+    getDocumentMode(document: Document): DOCUMENT_MODE {
+        return document.mode;
+    },
+
+    detachNode(node: ChildNode): void {
+        if (node.parentNode) {
+            const idx = node.parentNode.childNodes.indexOf(node);
+
+            node.parentNode.childNodes.splice(idx, 1);
+            node.parentNode = null;
+        }
+    },
+
+    insertText(parentNode: ParentNode, text: string): void {
+        if (parentNode.childNodes.length > 0) {
+            const prevNode = parentNode.childNodes[parentNode.childNodes.length - 1];
+
+            if (defaultTreeAdapter.isTextNode(prevNode)) {
+                prevNode.value += text;
+                return;
+            }
+        }
+
+        defaultTreeAdapter.appendChild(parentNode, createTextNode(text));
+    },
+
+    insertTextBefore(parentNode: ParentNode, text: string, referenceNode: ChildNode): void {
+        const prevNode = parentNode.childNodes[parentNode.childNodes.indexOf(referenceNode) - 1];
+
+        if (prevNode && defaultTreeAdapter.isTextNode(prevNode)) {
             prevNode.value += text;
-            return;
+        } else {
+            defaultTreeAdapter.insertBefore(parentNode, createTextNode(text), referenceNode);
         }
-    }
+    },
 
-    appendChild(parentNode, createTextNode(text));
-}
+    adoptAttributes(recipient: Element, attrs: Attribute[]): void {
+        const recipientAttrsMap = new Set(recipient.attrs.map((attr) => attr.name));
 
-export function insertTextBefore(parentNode: ParentNode, text: string, referenceNode: ChildNode): void {
-    const prevNode = parentNode.childNodes[parentNode.childNodes.indexOf(referenceNode) - 1];
-
-    if (prevNode && isTextNode(prevNode)) {
-        prevNode.value += text;
-    } else {
-        insertBefore(parentNode, createTextNode(text), referenceNode);
-    }
-}
-
-export function adoptAttributes(recipient: Element, attrs: Attribute[]): void {
-    const recipientAttrsMap = new Set(recipient.attrs.map((attr) => attr.name));
-
-    for (let j = 0; j < attrs.length; j++) {
-        if (!recipientAttrsMap.has(attrs[j].name)) {
-            recipient.attrs.push(attrs[j]);
+        for (let j = 0; j < attrs.length; j++) {
+            if (!recipientAttrsMap.has(attrs[j].name)) {
+                recipient.attrs.push(attrs[j]);
+            }
         }
-    }
-}
+    },
 
-//Tree traversing
-export function getFirstChild(node: ParentNode): null | ChildNode {
-    return node.childNodes[0];
-}
+    //Tree traversing
+    getFirstChild(node: ParentNode): null | ChildNode {
+        return node.childNodes[0];
+    },
 
-export function getChildNodes(node: ParentNode): ChildNode[] {
-    return node.childNodes;
-}
+    getChildNodes(node: ParentNode): ChildNode[] {
+        return node.childNodes;
+    },
 
-export function getParentNode(node: ChildNode): null | ParentNode {
-    return node.parentNode;
-}
+    getParentNode(node: ChildNode): null | ParentNode {
+        return node.parentNode;
+    },
 
-export function getAttrList(element: Element): Attribute[] {
-    return element.attrs;
-}
+    getAttrList(element: Element): Attribute[] {
+        return element.attrs;
+    },
 
-//Node data
-export function getTagName(element: Element): string {
-    return element.tagName;
-}
+    //Node data
+    getTagName(element: Element): string {
+        return element.tagName;
+    },
 
-export function getNamespaceURI(element: Element): NAMESPACES {
-    return element.namespaceURI;
-}
+    getNamespaceURI(element: Element): NAMESPACES {
+        return element.namespaceURI;
+    },
 
-export function getTextNodeContent(textNode: TextNode): string {
-    return textNode.value;
-}
+    getTextNodeContent(textNode: TextNode): string {
+        return textNode.value;
+    },
 
-export function getCommentNodeContent(commentNode: CommentNode): string {
-    return commentNode.data;
-}
+    getCommentNodeContent(commentNode: CommentNode): string {
+        return commentNode.data;
+    },
 
-export function getDocumentTypeNodeName(doctypeNode: DocumentType): string {
-    return doctypeNode.name;
-}
+    getDocumentTypeNodeName(doctypeNode: DocumentType): string {
+        return doctypeNode.name;
+    },
 
-export function getDocumentTypeNodePublicId(doctypeNode: DocumentType): string {
-    return doctypeNode.publicId;
-}
+    getDocumentTypeNodePublicId(doctypeNode: DocumentType): string {
+        return doctypeNode.publicId;
+    },
 
-export function getDocumentTypeNodeSystemId(doctypeNode: DocumentType): string {
-    return doctypeNode.systemId;
-}
+    getDocumentTypeNodeSystemId(doctypeNode: DocumentType): string {
+        return doctypeNode.systemId;
+    },
 
-//Node types
-export function isTextNode(node: Node): node is TextNode {
-    return node.nodeName === '#text';
-}
+    //Node types
+    isTextNode(node: Node): node is TextNode {
+        return node.nodeName === '#text';
+    },
 
-export function isCommentNode(node: Node): node is CommentNode {
-    return node.nodeName === '#comment';
-}
+    isCommentNode(node: Node): node is CommentNode {
+        return node.nodeName === '#comment';
+    },
 
-export function isDocumentTypeNode(node: Node): node is DocumentType {
-    return node.nodeName === NodeType.DocumentType;
-}
+    isDocumentTypeNode(node: Node): node is DocumentType {
+        return node.nodeName === NodeType.DocumentType;
+    },
 
-export function isElementNode(node: Node): node is Element {
-    return Object.prototype.hasOwnProperty.call(node, 'tagName');
-}
+    isElementNode(node: Node): node is Element {
+        return Object.prototype.hasOwnProperty.call(node, 'tagName');
+    },
 
-// Source code location
-export function setNodeSourceCodeLocation(node: Node, location: ElementLocation | null): void {
-    node.sourceCodeLocation = location;
-}
+    // Source code location
+    setNodeSourceCodeLocation(node: Node, location: ElementLocation | null): void {
+        node.sourceCodeLocation = location;
+    },
 
-export function getNodeSourceCodeLocation(node: Node): ElementLocation | undefined | null {
-    return node.sourceCodeLocation;
-}
+    getNodeSourceCodeLocation(node: Node): ElementLocation | undefined | null {
+        return node.sourceCodeLocation;
+    },
 
-export function updateNodeSourceCodeLocation(node: Node, endLocation: ElementLocation): void {
-    node.sourceCodeLocation = { ...node.sourceCodeLocation, ...endLocation };
-}
+    updateNodeSourceCodeLocation(node: Node, endLocation: ElementLocation): void {
+        node.sourceCodeLocation = { ...node.sourceCodeLocation, ...endLocation };
+    },
+};

--- a/scripts/generate-parser-feedback-test/index.ts
+++ b/scripts/generate-parser-feedback-test/index.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { Parser } from 'parse5/dist/parser/index.js';
-import * as defaultTreeAdapter from 'parse5/dist/tree-adapters/default.js';
+import { type DefaultTreeAdapterMap, defaultTreeAdapter } from 'parse5/dist/tree-adapters/default.js';
 import { HtmlLibToken } from 'parse5-test-utils/utils/generate-tokenization-tests.js';
 import { parseDatFile } from 'parse5-test-utils/utils/parse-dat-file.js';
 import { addSlashes } from 'parse5-test-utils/utils/common.js';
@@ -124,7 +124,7 @@ function collectParserTokens(html: string): HtmlLibToken[] {
 }
 
 function generateParserFeedbackTest(parserTestFile: string): string {
-    const tests = parseDatFile<defaultTreeAdapter.DefaultTreeAdapterMap>(parserTestFile, defaultTreeAdapter);
+    const tests = parseDatFile<DefaultTreeAdapterMap>(parserTestFile, defaultTreeAdapter);
 
     const feedbackTest = {
         tests: tests.map(({ input, fragmentContext }) => ({

--- a/test/utils/common.ts
+++ b/test/utils/common.ts
@@ -1,16 +1,13 @@
 import { Writable, Readable, finished as finishedCb } from 'node:stream';
 import * as assert from 'node:assert';
 import type { TreeAdapter } from 'parse5/dist/tree-adapters/interface.js';
-import * as defaultTreeAdapter from 'parse5/dist/tree-adapters/default.js';
-import * as htmlTreeAdapter from 'parse5-htmlparser2-tree-adapter';
+import { defaultTreeAdapter } from 'parse5/dist/tree-adapters/default.js';
+import { adapter as htmlparser2Adapter } from 'parse5-htmlparser2-tree-adapter';
 import type { Location } from 'parse5/dist/common/token.js';
-
-const defaultAdapter: TreeAdapter<defaultTreeAdapter.DefaultTreeAdapterMap> = defaultTreeAdapter;
-const htmlparser2Adapter: TreeAdapter<htmlTreeAdapter.Htmlparser2TreeAdapterMap> = htmlTreeAdapter;
 
 // Ensure the default tree adapter matches the expected type.
 export const treeAdapters = {
-    default: defaultAdapter,
+    default: defaultTreeAdapter,
     htmlparser2: htmlparser2Adapter,
 } as const;
 


### PR DESCRIPTION
@43081j already had this in his TS conversion. Makes us use objects for the adapters, which allows TS to properly type check them. This means we will have to type the default options as `{Parser,Serializer}Options<any>`; please let me know if you can think of an alternative approach to make this type safe.