### PR TITLE
Bump `entities` to `4.1.1`, update code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2322,9 +2322,9 @@
             "dev": true
         },
         "node_modules/entities": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.0.0.tgz",
+            "integrity": "sha512-4v2Nrbg5YsidL0sfsj05GSI86KCn2IJX3TlUq11aDUIq0O5iICDGI/WwVUS7hKPBhfoKr9E4e2Jx8A7rDbpg/w==",
             "engines": {
                 "node": ">=0.12"
             },
@@ -6279,7 +6279,7 @@
             "version": "6.0.1",
             "license": "MIT",
             "dependencies": {
-                "entities": "^3.0.1"
+                "entities": "^4.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -6289,6 +6289,7 @@
             "version": "6.0.1",
             "license": "MIT",
             "dependencies": {
+                "entities": "^4.0.0",
                 "parse5": "^6.0.1",
                 "parse5-sax-parser": "^6.0.1"
             },
@@ -8084,9 +8085,9 @@
             "dev": true
         },
         "entities": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-            "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.0.0.tgz",
+            "integrity": "sha512-4v2Nrbg5YsidL0sfsj05GSI86KCn2IJX3TlUq11aDUIq0O5iICDGI/WwVUS7hKPBhfoKr9E4e2Jx8A7rDbpg/w=="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -9946,7 +9947,7 @@
         "parse5": {
             "version": "file:packages/parse5",
             "requires": {
-                "entities": "^3.0.1"
+                "entities": "^4.0.0"
             }
         },
         "parse5-benchmarks": {
@@ -9968,6 +9969,7 @@
         "parse5-html-rewriting-stream": {
             "version": "file:packages/parse5-html-rewriting-stream",
             "requires": {
+                "entities": "4.0.0",
                 "parse5": "^6.0.1",
                 "parse5-sax-parser": "^6.0.1"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2322,9 +2322,9 @@
             "dev": true
         },
         "node_modules/entities": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.0.0.tgz",
-            "integrity": "sha512-4v2Nrbg5YsidL0sfsj05GSI86KCn2IJX3TlUq11aDUIq0O5iICDGI/WwVUS7hKPBhfoKr9E4e2Jx8A7rDbpg/w==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.1.1.tgz",
+            "integrity": "sha512-AxszXDqnHj5aVzjBpofDDfXX9zC8gugYwJxEYDdA52d6dqoxPKfNDBFxZyIZrkaqUtNy/ip/knBm6mRJed7p1A==",
             "engines": {
                 "node": ">=0.12"
             },
@@ -6279,7 +6279,7 @@
             "version": "6.0.1",
             "license": "MIT",
             "dependencies": {
-                "entities": "^4.0.0"
+                "entities": "^4.1.1"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -6289,7 +6289,7 @@
             "version": "6.0.1",
             "license": "MIT",
             "dependencies": {
-                "entities": "^4.0.0",
+                "entities": "^4.1.1",
                 "parse5": "^6.0.1",
                 "parse5-sax-parser": "^6.0.1"
             },
@@ -8085,9 +8085,9 @@
             "dev": true
         },
         "entities": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.0.0.tgz",
-            "integrity": "sha512-4v2Nrbg5YsidL0sfsj05GSI86KCn2IJX3TlUq11aDUIq0O5iICDGI/WwVUS7hKPBhfoKr9E4e2Jx8A7rDbpg/w=="
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.1.1.tgz",
+            "integrity": "sha512-AxszXDqnHj5aVzjBpofDDfXX9zC8gugYwJxEYDdA52d6dqoxPKfNDBFxZyIZrkaqUtNy/ip/knBm6mRJed7p1A=="
         },
         "error-ex": {
             "version": "1.3.2",
@@ -9947,7 +9947,7 @@
         "parse5": {
             "version": "file:packages/parse5",
             "requires": {
-                "entities": "^4.0.0"
+                "entities": "4.1.1"
             }
         },
         "parse5-benchmarks": {
@@ -9969,7 +9969,7 @@
         "parse5-html-rewriting-stream": {
             "version": "file:packages/parse5-html-rewriting-stream",
             "requires": {
-                "entities": "4.0.0",
+                "entities": "^4.1.1",
                 "parse5": "^6.0.1",
                 "parse5-sax-parser": "^6.0.1"
             }

--- a/packages/parse5-html-rewriting-stream/lib/index.ts
+++ b/packages/parse5-html-rewriting-stream/lib/index.ts
@@ -1,6 +1,7 @@
+import { escapeText, escapeAttribute } from 'entities';
 import type { Location } from 'parse5/dist/common/token.js';
 import { SAXParser, EndTag, StartTag, Doctype, Text, Comment, SaxToken } from 'parse5-sax-parser';
-import { hasUnescapedText, escapeString } from 'parse5/dist/serializer/index.js';
+import { hasUnescapedText } from 'parse5/dist/serializer/index.js';
 
 /**
  * Streaming [SAX](https://en.wikipedia.org/wiki/Simple_API_for_XML)-style HTML rewriter.
@@ -113,7 +114,7 @@ export class RewritingStream extends SAXParser {
         let res = `<${token.tagName}`;
 
         for (const attr of token.attrs) {
-            res += ` ${attr.name}="${escapeString(attr.value, true)}"`;
+            res += ` ${attr.name}="${escapeAttribute(attr.value)}"`;
         }
 
         res += token.selfClosing ? '/>' : '>';
@@ -131,7 +132,7 @@ export class RewritingStream extends SAXParser {
         this.push(
             !this.parserFeedbackSimulator.inForeignContent && hasUnescapedText(this.tokenizer.lastStartTagName, true)
                 ? text
-                : escapeString(text, false)
+                : escapeText(text)
         );
     }
 

--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -20,6 +20,7 @@
     "main": "dist/index.js",
     "exports": "dist/index.js",
     "dependencies": {
+        "entities": "^4.0.0",
         "parse5": "^6.0.1",
         "parse5-sax-parser": "^6.0.1"
     },

--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -20,7 +20,7 @@
     "main": "dist/index.js",
     "exports": "dist/index.js",
     "dependencies": {
-        "entities": "^4.0.0",
+        "entities": "^4.1.1",
         "parse5": "^6.0.1",
         "parse5-sax-parser": "^6.0.1"
     },

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -1,13 +1,7 @@
+import { escapeText, escapeAttribute } from 'entities';
 import { TAG_NAMES as $, NAMESPACES as NS } from '../common/html.js';
 import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface';
 import { defaultTreeAdapter, type DefaultTreeAdapterMap } from '../tree-adapters/default.js';
-
-//Escaping regexes
-const AMP_REGEX = /&/g;
-const NBSP_REGEX = /\u00A0/g;
-const DOUBLE_QUOTE_REGEX = /"/g;
-const LT_REGEX = /</g;
-const GT_REGEX = />/g;
 
 // Sets
 const VOID_ELEMENTS = new Set<string>([
@@ -208,7 +202,7 @@ function serializeAttributes<T extends TreeAdapterTypeMap>(
                 }
             }
 
-        html += `="${escapeString(attr.value, true)}"`;
+        html += `="${escapeAttribute(attr.value)}"`;
     }
 
     return html;
@@ -224,7 +218,7 @@ function serializeTextNode<T extends TreeAdapterTypeMap>(node: T['textNode'], op
         treeAdapter.getNamespaceURI(parent) === NS.HTML &&
         hasUnescapedText(parentTn, options.scriptingEnabled)
         ? content
-        : escapeString(content, false);
+        : escapeText(content);
 }
 
 function serializeCommentNode<T extends TreeAdapterTypeMap>(
@@ -239,13 +233,4 @@ function serializeDocumentTypeNode<T extends TreeAdapterTypeMap>(
     { treeAdapter }: InternalOptions<T>
 ): string {
     return `<!DOCTYPE ${treeAdapter.getDocumentTypeNodeName(node)}>`;
-}
-
-// NOTE: used in tests and by rewriting stream
-export function escapeString(str: string, attrMode = false): string {
-    str = str.replace(AMP_REGEX, '&amp;').replace(NBSP_REGEX, '&nbsp;');
-
-    return attrMode
-        ? str.replace(DOUBLE_QUOTE_REGEX, '&quot;')
-        : str.replace(LT_REGEX, '&lt;').replace(GT_REGEX, '&gt;');
 }

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -8,7 +8,7 @@
     "homepage": "https://github.com/inikulin/parse5",
     "funding": "https://github.com/inikulin/parse5?sponsor=1",
     "dependencies": {
-        "entities": "^3.0.1"
+        "entities": "^4.0.0"
     },
     "keywords": [
         "html",

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -8,7 +8,7 @@
     "homepage": "https://github.com/inikulin/parse5",
     "funding": "https://github.com/inikulin/parse5?sponsor=1",
     "dependencies": {
-        "entities": "^4.0.0"
+        "entities": "^4.1.1"
     },
     "keywords": [
         "html",


### PR DESCRIPTION
`entities` is now an ES Module, which should make ES Module fans happy. (No more CJS dependencies!)

The new version features a smaller decode tree, which required an update to the tokenizer. It also includes `escapeText` and `escapeAttribute` functions that implement the required behavior for the HTML serializer; I replaced parse5's `escapeString` function with these.