### PR TITLE
fix(package): Don't publish source maps

### DIFF
--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -31,6 +31,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist"
+        "dist",
+        "!*.map"
     ]
 }

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -33,6 +33,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist"
+        "dist",
+        "!*.map"
     ]
 }

--- a/packages/parse5-parser-stream/package.json
+++ b/packages/parse5-parser-stream/package.json
@@ -26,6 +26,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist"
+        "dist",
+        "!*.map"
     ]
 }

--- a/packages/parse5-plain-text-conversion-stream/package.json
+++ b/packages/parse5-plain-text-conversion-stream/package.json
@@ -30,6 +30,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist"
+        "dist",
+        "!*.map"
     ]
 }

--- a/packages/parse5-sax-parser/package.json
+++ b/packages/parse5-sax-parser/package.json
@@ -27,6 +27,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist"
+        "dist",
+        "!*.map"
     ]
 }

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -43,6 +43,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist"
+        "dist",
+        "!*.map"
     ]
 }


### PR DESCRIPTION
The root `tsconfig.json` file asks for source maps to be generated. If we ship these with the published packages, they will point at the `.ts` files in the relative directory, which aren't shipped with the packages. This makes the source maps useless for debugging, and a source of errors otherwise.

I originally wanted to adopt the approach from `entities`, where I used the `sourceRoot` field to point to the original source files on GitHub (https://github.com/fb55/entities/pull/788). Unfortunately, this doesn't work with `tsc --build` (https://github.com/microsoft/TypeScript/issues/25613) and would require a work-around[^1].

[^1]:  Something along the lines of defining a source root in each package's `tsconfig.json`, then updating all of them to point to a specific commit in a `sed` script.