### PR TITLE
docs: Fix small typo in code example

### DIFF
--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -57,7 +57,7 @@ export function parse<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
  * console.log(documentFragment.childNodes[0].tagName); //> 'table'
  *
  * // Parses the html fragment in the context of the parsed <table> element.
- * const trFragment = parser.parseFragment(documentFragment.childNodes[0], '<tr><td>Shake it, baby</td></tr>');
+ * const trFragment = parse5.parseFragment(documentFragment.childNodes[0], '<tr><td>Shake it, baby</td></tr>');
  *
  * console.log(trFragment.childNodes[0].childNodes[0].tagName); //> 'td'
  * ```


### PR DESCRIPTION
Page: https://parse5.js.org/modules/parse5.html#parseFragment

Variable `parser` should be `parse5`. As it's declared in beginning of the code example `const parse5 = require('parse5');`, `parser` variable would be undefined.