### PR TITLE
chore(deps): Bump domhandler, remove cast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,9 +2265,9 @@
             }
         },
         "node_modules/domhandler": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
-            "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "dependencies": {
                 "domelementtype": "^2.3.0"
             },
@@ -6294,7 +6294,7 @@
             "version": "7.0.0",
             "license": "MIT",
             "dependencies": {
-                "domhandler": "^5.0.2",
+                "domhandler": "^5.0.3",
                 "parse5": "^7.0.0"
             },
             "funding": {
@@ -8036,9 +8036,9 @@
             }
         },
         "domhandler": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
-            "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
             "requires": {
                 "domelementtype": "^2.3.0"
             }
@@ -9968,7 +9968,7 @@
         "parse5-htmlparser2-tree-adapter": {
             "version": "file:packages/parse5-htmlparser2-tree-adapter",
             "requires": {
-                "domhandler": "^5.0.2",
+                "domhandler": "^5.0.3",
                 "parse5": "^7.0.0"
             }
         },

--- a/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
+++ b/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
@@ -129,11 +129,11 @@ export const adapter: TreeAdapter<Htmlparser2TreeAdapterMap> = {
     },
 
     setTemplateContent(templateElement: Element, contentElement: Document): void {
-        adapter.appendChild(templateElement, contentElement as AnyNode as ChildNode);
+        adapter.appendChild(templateElement, contentElement);
     },
 
     getTemplateContent(templateElement: Element): Document {
-        return templateElement.children[0] as AnyNode as Document;
+        return templateElement.children[0] as Document;
     },
 
     setDocumentType(document: Document, name: string, publicId: string, systemId: string): void {

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -22,7 +22,7 @@
         "require": "./dist/cjs/index.js"
     },
     "dependencies": {
-        "domhandler": "^5.0.2",
+        "domhandler": "^5.0.3",
         "parse5": "^7.0.0"
     },
     "scripts": {


### PR DESCRIPTION
domhandler now allows `Document` nodes as children. This allows us to remove a cast from the relevant adapter.