### PR TITLE
refactor: Several small changes

### DIFF
--- a/packages/parse5-parser-stream/test/parser-stream.test.ts
+++ b/packages/parse5-parser-stream/test/parser-stream.test.ts
@@ -11,12 +11,12 @@ generateParsingTests(
         expectErrors: [
             //TODO(GH-448): Foreign content behaviour was updated in the HTML spec.
             //The old test suite still tests the old behaviour.
-            '269.foreign-fragment',
-            '270.foreign-fragment',
-            '307.foreign-fragment',
-            '309.foreign-fragment',
-            '316.foreign-fragment',
-            '317.foreign-fragment',
+            '0.foreign-fragment',
+            '1.foreign-fragment',
+            '38.foreign-fragment',
+            '40.foreign-fragment',
+            '47.foreign-fragment',
+            '48.foreign-fragment',
         ],
     },
     (test, opts) => parseChunked(test, opts)

--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -11,12 +11,12 @@ generateParsingTests(
         expectErrors: [
             //TODO(GH-448): Foreign content behaviour was updated in the HTML spec.
             //The old test suite still tests the old behaviour.
-            '269.foreign-fragment',
-            '270.foreign-fragment',
-            '307.foreign-fragment',
-            '309.foreign-fragment',
-            '316.foreign-fragment',
-            '317.foreign-fragment',
+            '0.foreign-fragment',
+            '1.foreign-fragment',
+            '38.foreign-fragment',
+            '40.foreign-fragment',
+            '47.foreign-fragment',
+            '48.foreign-fragment',
         ],
     },
     (test, opts) => ({
@@ -30,7 +30,7 @@ generateParsingTests(
     {
         withoutErrors: true,
         suitePath: new URL('../../../../test/data/html5lib-tests/tree-construction', import.meta.url),
-        expectErrors: ['505.search-element', '506.search-element'],
+        expectErrors: ['0.search-element', '1.search-element'],
     },
     (test, opts) => ({
         node: test.fragmentContext ? parseFragment(test.fragmentContext, test.input, opts) : parse(test.input, opts),

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -1573,25 +1573,29 @@ function endTagInHead<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToke
             break;
         }
         case $.TEMPLATE: {
-            if (p.openElements.tmplCount > 0) {
-                p.openElements.generateImpliedEndTagsThoroughly();
-
-                if (p.openElements.currentTagId !== $.TEMPLATE) {
-                    p._err(token, ERR.closingOfElementWithOpenChildElements);
-                }
-
-                p.openElements.popUntilTagNamePopped($.TEMPLATE);
-                p.activeFormattingElements.clearToLastMarker();
-                p.tmplInsertionModeStack.shift();
-                p._resetInsertionMode();
-            } else {
-                p._err(token, ERR.endTagWithoutMatchingOpenElement);
-            }
+            templateEndTagInHead<T>(p, token);
             break;
         }
         default: {
             p._err(token, ERR.endTagWithoutMatchingOpenElement);
         }
+    }
+}
+
+function templateEndTagInHead<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToken): void {
+    if (p.openElements.tmplCount > 0) {
+        p.openElements.generateImpliedEndTagsThoroughly();
+
+        if (p.openElements.currentTagId !== $.TEMPLATE) {
+            p._err(token, ERR.closingOfElementWithOpenChildElements);
+        }
+
+        p.openElements.popUntilTagNamePopped($.TEMPLATE);
+        p.activeFormattingElements.clearToLastMarker();
+        p.tmplInsertionModeStack.shift();
+        p._resetInsertionMode();
+    } else {
+        p._err(token, ERR.endTagWithoutMatchingOpenElement);
     }
 }
 
@@ -1709,7 +1713,7 @@ function endTagAfterHead<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagT
             break;
         }
         case $.TEMPLATE: {
-            endTagInHead(p, token);
+            templateEndTagInHead(p, token);
             break;
         }
         default: {
@@ -2526,7 +2530,7 @@ function endTagInBody<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToke
             break;
         }
         case $.TEMPLATE: {
-            endTagInHead(p, token);
+            templateEndTagInHead(p, token);
             break;
         }
         default: {
@@ -2705,7 +2709,7 @@ function endTagInTable<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagTok
             break;
         }
         case $.TEMPLATE: {
-            endTagInHead(p, token);
+            templateEndTagInHead(p, token);
             break;
         }
         case $.BODY:
@@ -2855,7 +2859,7 @@ function endTagInColumnGroup<T extends TreeAdapterTypeMap>(p: Parser<T>, token: 
             break;
         }
         case $.TEMPLATE: {
-            endTagInHead(p, token);
+            templateEndTagInHead(p, token);
             break;
         }
         case $.COL: {
@@ -3168,7 +3172,7 @@ function endTagInSelect<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagTo
             break;
         }
         case $.TEMPLATE: {
-            endTagInHead(p, token);
+            templateEndTagInHead(p, token);
             break;
         }
         default:
@@ -3275,7 +3279,7 @@ function startTagInTemplate<T extends TreeAdapterTypeMap>(p: Parser<T>, token: T
 
 function endTagInTemplate<T extends TreeAdapterTypeMap>(p: Parser<T>, token: TagToken): void {
     if (token.tagID === $.TEMPLATE) {
-        endTagInHead(p, token);
+        templateEndTagInHead(p, token);
     }
 }
 

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -56,4 +56,10 @@ describe('serializer', () => {
 
         assert.equal(serialize(svgBr), '<div></div>');
     });
+
+    it('serializes unknown node to empty string', () => {
+        const unknown: any = {};
+        assert.strictEqual(serialize(unknown), '');
+        assert.strictEqual(serializeOuter(unknown), '');
+    });
 });

--- a/packages/parse5/lib/tokenizer/index.test.ts
+++ b/packages/parse5/lib/tokenizer/index.test.ts
@@ -47,5 +47,13 @@ describe('Tokenizer methods', () => {
         expect(tokenizer).toHaveProperty('paused', true);
 
         tokenizer.resume();
+
+        assert.strictEqual(count, 4);
+    });
+
+    it('should throw if setting the state to an unknown value', () => {
+        const tokenizer = new Tokenizer(tokenizerOpts, {} as any);
+        tokenizer.state = -1;
+        expect(() => tokenizer.write('foo', true)).toThrow('Unknown state');
     });
 });

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -583,13 +583,11 @@ export class Tokenizer {
     }
 
     private _emitCodePoint(cp: number): void {
-        let type = TokenType.CHARACTER;
-
-        if (isWhitespace(cp)) {
-            type = TokenType.WHITESPACE_CHARACTER;
-        } else if (cp === $.NULL) {
-            type = TokenType.NULL_CHARACTER;
-        }
+        const type = isWhitespace(cp)
+            ? TokenType.WHITESPACE_CHARACTER
+            : cp === $.NULL
+            ? TokenType.NULL_CHARACTER
+            : TokenType.CHARACTER;
 
         this._appendCharToCurrentCharacterToken(type, String.fromCodePoint(cp));
     }

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -353,9 +353,9 @@ export class Tokenizer {
         this.preprocessor.retreat(count);
     }
 
-    private _reconsumeInState(state: State): void {
+    private _reconsumeInState(state: State, cp: number): void {
         this.state = state;
-        this._unconsume(1);
+        this._callState(cp);
     }
 
     private _advanceBy(count: number): void {
@@ -1001,7 +1001,7 @@ export class Tokenizer {
                 break;
             }
             case State.NUMERIC_CHARACTER_REFERENCE_END: {
-                this._stateNumericCharacterReferenceEnd();
+                this._stateNumericCharacterReferenceEnd(cp);
                 break;
             }
             default: {
@@ -2979,7 +2979,7 @@ export class Tokenizer {
             this._stateNamedCharacterReference(cp);
         } else {
             this._flushCodePointConsumedAsCharacterReference($.AMPERSAND);
-            this._reconsumeInState(this.returnState);
+            this._reconsumeInState(this.returnState, cp);
         }
     }
 
@@ -3013,7 +3013,7 @@ export class Tokenizer {
                 this._err(ERR.unknownNamedCharacterReference);
             }
 
-            this._reconsumeInState(this.returnState);
+            this._reconsumeInState(this.returnState, cp);
         }
     }
 
@@ -3033,7 +3033,7 @@ export class Tokenizer {
             this._err(ERR.absenceOfDigitsInNumericCharacterReference);
             this._flushCodePointConsumedAsCharacterReference($.AMPERSAND);
             this._flushCodePointConsumedAsCharacterReference($.NUMBER_SIGN);
-            this._reconsumeInState(this.returnState);
+            this._reconsumeInState(this.returnState, cp);
         }
     }
 
@@ -3066,7 +3066,7 @@ export class Tokenizer {
         } else {
             this._err(ERR.missingSemicolonAfterCharacterReference);
             this.state = State.NUMERIC_CHARACTER_REFERENCE_END;
-            this._stateNumericCharacterReferenceEnd();
+            this._stateNumericCharacterReferenceEnd(cp);
         }
     }
 
@@ -3080,13 +3080,13 @@ export class Tokenizer {
         } else {
             this._err(ERR.missingSemicolonAfterCharacterReference);
             this.state = State.NUMERIC_CHARACTER_REFERENCE_END;
-            this._stateNumericCharacterReferenceEnd();
+            this._stateNumericCharacterReferenceEnd(cp);
         }
     }
 
     // Numeric character reference end state
     //------------------------------------------------------------------
-    private _stateNumericCharacterReferenceEnd(): void {
+    private _stateNumericCharacterReferenceEnd(cp: number): void {
         if (this.charRefCode === $.NULL) {
             this._err(ERR.nullCharacterReference);
             this.charRefCode = $.REPLACEMENT_CHARACTER;
@@ -3109,6 +3109,6 @@ export class Tokenizer {
         }
 
         this._flushCodePointConsumedAsCharacterReference(this.charRefCode);
-        this._reconsumeInState(this.returnState);
+        this._reconsumeInState(this.returnState, cp);
     }
 }

--- a/test/utils/generate-parsing-tests.ts
+++ b/test/utils/generate-parsing-tests.ts
@@ -31,10 +31,10 @@ export function loadTreeConstructionTestData<T extends TreeAdapterTypeMap>(
         const testSet = fs.readFileSync(filePath, 'utf8');
         const setName = fileName.replace('.dat', '');
 
-        for (const test of parseDatFile(testSet, treeAdapter)) {
+        for (const [idx, test] of parseDatFile(testSet, treeAdapter).entries()) {
             tests.push({
                 ...test,
-                idx: tests.length,
+                idx,
                 setName,
                 dirName,
             });


### PR DESCRIPTION
This is a bundle of several small changes that came up with https://github.com/html5lib/html5lib-tests/pull/147

Overview over the changes:

- `reconsumeInState` will now call the state directly, instead of retreating.
- We knew in several places that we wanted to get to the template end logic of the _in head_ insertion mode. By factoring out that insertion mode, we can skip some steps.
- Added a test for serialising unknown nodes (which should lead to an empty string)
- Test indices were previously global, which resulted in ignores failing after an unrelated test was added. Now, test indices are local.
- Simplify a conditional statement to a ternary (following the [Principle of Most Restrictive Production](https://blog.izs.me/2022/04/principle-of-most-restrictive-production/))