### PR TITLE
refactor(tsconfig): Set `module` to `Node16`

### DIFF
--- a/packages/parse5/lib/parser/formatting-element-list.ts
+++ b/packages/parse5/lib/parser/formatting-element-list.ts
@@ -1,5 +1,5 @@
 import type { Attribute, TagToken } from '../common/token.js';
-import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface';
+import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface.js';
 
 //Const
 const NOAH_ARK_CAPACITY = 3;

--- a/packages/parse5/lib/parser/open-element-stack.ts
+++ b/packages/parse5/lib/parser/open-element-stack.ts
@@ -1,5 +1,5 @@
 import { TAG_ID as $, NS, isNumberedHeader } from '../common/html.js';
-import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface';
+import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface.js';
 
 //Element utils
 const IMPLICIT_END_TAG_REQUIRED = new Set([$.DD, $.DT, $.LI, $.OPTGROUP, $.OPTION, $.P, $.RB, $.RP, $.RT, $.RTC]);

--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -1,6 +1,6 @@
 import { TAG_NAMES as $, NS, hasUnescapedText } from '../common/html.js';
 import { escapeText, escapeAttribute } from 'entities/lib/escape.js';
-import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface';
+import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface.js';
 import { defaultTreeAdapter, type DefaultTreeAdapterMap } from '../tree-adapters/default.js';
 
 // Sets

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "es2019",
         "module": "Node16",
+        "moduleResolution": "Node16",
         "strict": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitOverride": true,
         "noPropertyAccessFromIndexSignature": true,
-        "moduleResolution": "node",
         "forceConsistentCasingInFileNames": true,
         "importsNotUsedAsValues": "error",
         "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es2019",
-        "module": "esnext",
+        "module": "Node16",
         "strict": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,


### PR DESCRIPTION
Also explicitly sets `moduleResolution`. This reported some missing file extensions for type imports, which were added.

Fixes #556