### PR TITLE
chore(ci): Pin GitHub Action dependency versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,14 +20,14 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v3.0.2
               with:
                   submodules: recursive
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v2
+              uses: github/codeql-action/init@v2.10.2
               with:
                   languages: 'javascript'
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v2
+              uses: github/codeql-action/analyze@v2.10.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,9 +25,9 @@ jobs:
                   submodules: recursive
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v2.10.2
+              uses: github/codeql-action/init@v2.1.22
               with:
                   languages: 'javascript'
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v2.10.2
+              uses: github/codeql-action/analyze@v2.1.22

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -18,10 +18,10 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v3.0.2
               with:
                   submodules: recursive
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v3.4.1
               with:
                   node-version: lts/*
                   cache: npm
@@ -45,15 +45,14 @@ jobs:
                     - lts/*
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v3.0.2
               with:
                   submodules: recursive
             - name: Use Node.js ${{ matrix.node }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v3.4.1
               with:
                   node-version: ${{ matrix.node }}
                   cache: npm
-            - run: npm install -g npm@8
             - run: npm ci
             - run: npm run build --if-present
 

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -39,9 +39,9 @@ jobs:
             fail-fast: false
             matrix:
                 node:
-                    - 14
-                    - 16
-                    - 18
+                    - '14'
+                    - '16'
+                    - '18'
                     - lts/*
 
         steps:
@@ -53,6 +53,8 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
                   cache: npm
+            - run: npm install -g npm@8.19.1
+              if: matrix.node == '14'
             - run: npm ci
             - run: npm run build --if-present
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,8 +9,8 @@ jobs:
         name: Deploy to GitHub Pages
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v3.0.2
+            - uses: actions/setup-node@v3.4.1
               with:
                   node-version: lts/*
                   cache: npm
@@ -18,7 +18,7 @@ jobs:
             - name: Build docs
               run: npm run build:docs
             - name: Deploy
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@v3.8.0
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_dir: docs/build


### PR DESCRIPTION
Dependabot will now update them as new versions are released.

This is done to improve parse5's score in the OpenSSF scorecard, visible here: https://deps.dev/npm/parse5