### PR TITLE
Bump parse5 to 7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6012,7 +6012,7 @@
             }
         },
         "packages/parse5": {
-            "version": "7.0.0",
+            "version": "7.1.0",
             "license": "MIT",
             "dependencies": {
                 "entities": "^4.4.0"

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -2,7 +2,7 @@
     "name": "parse5",
     "type": "module",
     "description": "HTML parser and serializer.",
-    "version": "7.0.0",
+    "version": "7.1.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://github.com/inikulin/parse5",


### PR DESCRIPTION
This version is already on npm — forgot that I should PR the release first.

Once this is merged, I'll create a tag and publish release notes.

My gut feeling is that, going forward we should skip versions for the other packages, so that versions numbers across packages are monotonically increasing. (Ie. `parse5-rewriter-stream@7.8.9` is guaranteed to be published after `parse5@7.6.5`.)