### PR TITLE
fix(package): Fix CJS bundle, bump to parse5@7.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,11 @@
             }
         },
         "bench/node_modules/parse5": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-            "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
+            "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
             "dependencies": {
-                "entities": "^4.3.0"
+                "entities": "^4.4.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -6012,7 +6012,7 @@
             }
         },
         "packages/parse5": {
-            "version": "7.1.0",
+            "version": "7.1.1",
             "license": "MIT",
             "dependencies": {
                 "entities": "^4.4.0"
@@ -9528,11 +9528,11 @@
             },
             "dependencies": {
                 "parse5": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-                    "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
+                    "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
                     "requires": {
-                        "entities": "^4.3.0"
+                        "entities": "^4.4.0"
                     }
                 }
             }

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -33,6 +33,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
+        "dist/cjs/package.json",
         "dist/**/*.js",
         "dist/**/*.d.ts"
     ]

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -2,7 +2,7 @@
     "name": "parse5",
     "type": "module",
     "description": "HTML parser and serializer.",
-    "version": "7.1.0",
+    "version": "7.1.1",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://github.com/inikulin/parse5",
@@ -43,6 +43,7 @@
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
+        "dist/cjs/package.json",
         "dist/**/*.js",
         "dist/**/*.d.ts"
     ]


### PR DESCRIPTION
The `package.json` that's added for CJS was not added when we switched to a whitelist in #516.

Fixes #663