### PR TITLE
fix: export ERR as ErrorCodes from error-codes.js

### DIFF
--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -7,7 +7,7 @@ export { type DefaultTreeAdapterMap, defaultTreeAdapter } from './tree-adapters/
 export type { TreeAdapter, TreeAdapterTypeMap } from './tree-adapters/interface.js';
 export { type ParserOptions, /** @internal */ Parser } from './parser/index.js';
 export { serialize, serializeOuter, type SerializerOptions } from './serializer/index.js';
-export type { ParserError } from './common/error-codes.js';
+export { ERR as ErrorCodes, type ParserError } from './common/error-codes.js';
 
 /** @internal */
 export * as foreignContent from './common/foreign-content.js';


### PR DESCRIPTION
export error codes

fix #555

https://github.com/inikulin/parse5/pull/418#discussion_r997476069

<blockquote>

this breaks [rehype/test/parse-error.js](https://github.com/rehypejs/rehype/blob/620bb9cdf53a4dbe70adfca8d66c8824eb3f513f/test/parse-error.js#L7) in https://github.com/rehypejs/rehype/pull/113

```js
import p5errors from 'parse5/lib/common/error-codes.js'
```

> ```Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/common/error-codes.js' is not defined by "exports" in node_modules/parse5/package.json imported from test/parse-error.js```

wontfix in rehype, as [ERR](https://github.com/inikulin/parse5/blob/075be2e712644410e1ceae67ebabad958bc0b66e/packages/parse5/lib/common/error-codes.ts#L9) is not exported by parse5

&rarr; export as ErrorCodes?

https://nodejs.org/api/esm.html

> module files within packages can be accessed by appending a path to the package name **unless the package's [package.json](https://nodejs.org/api/packages.html#nodejs-packagejson-field-definitions) contains an ["exports"](https://nodejs.org/api/packages.html#exports) field, in which case files within packages can only be accessed via the paths defined in ["exports"](https://nodejs.org/api/packages.html#exports).**

</blockquote>
