### PR TITLE
fix(tokenizer): Properly handle CR when peeking

### DIFF
--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -78,6 +78,13 @@ describe('parser', () => {
         expect(doctype).toHaveProperty('systemId', '');
     });
 
+    it('Regression - CRLF inside </noscript> (GH-710)', () => {
+        const onParseError = jest.fn();
+        parse('<!doctype html><noscript>foo</noscript\r\n>', { onParseError });
+
+        expect(onParseError).not.toHaveBeenCalled();
+    });
+
     describe('Tree adapters', () => {
         it('should support onItemPush and onItemPop', () => {
             const onItemPush = jest.fn();

--- a/packages/parse5/lib/tokenizer/index.test.ts
+++ b/packages/parse5/lib/tokenizer/index.test.ts
@@ -1,4 +1,4 @@
-import { Tokenizer, TokenizerMode } from 'parse5';
+import { Tokenizer } from 'parse5';
 import { generateTokenizationTests } from 'parse5-test-utils/utils/generate-tokenization-tests.js';
 import * as assert from 'node:assert';
 
@@ -55,29 +55,5 @@ describe('Tokenizer methods', () => {
         const tokenizer = new Tokenizer(tokenizerOpts, {} as any);
         tokenizer.state = -1;
         expect(() => tokenizer.write('foo', true)).toThrow('Unknown state');
-    });
-
-    it('should stay in special state on CRLF inside </noscript> (GH-710)', () => {
-        let receivedEOF = false;
-
-        const tokenizer = new Tokenizer(tokenizerOpts, {
-            onEof(): void {
-                receivedEOF = true;
-            },
-            onComment: noop,
-            onDoctype: noop,
-            onStartTag: noop,
-            onEndTag: noop,
-            onCharacter: noop,
-            onNullCharacter: noop,
-            onWhitespaceCharacter: noop,
-        });
-
-        tokenizer.state = TokenizerMode.RAWTEXT;
-        tokenizer.lastStartTagName = 'noscript';
-
-        tokenizer.write('foo</noscript\r\n>', true);
-        expect(receivedEOF).toBeTruthy();
-        expect(tokenizer.state).toBe(TokenizerMode.DATA);
     });
 });

--- a/packages/parse5/lib/tokenizer/index.test.ts
+++ b/packages/parse5/lib/tokenizer/index.test.ts
@@ -1,4 +1,4 @@
-import { Tokenizer } from 'parse5';
+import { Tokenizer, TokenizerMode } from 'parse5';
 import { generateTokenizationTests } from 'parse5-test-utils/utils/generate-tokenization-tests.js';
 import * as assert from 'node:assert';
 
@@ -55,5 +55,29 @@ describe('Tokenizer methods', () => {
         const tokenizer = new Tokenizer(tokenizerOpts, {} as any);
         tokenizer.state = -1;
         expect(() => tokenizer.write('foo', true)).toThrow('Unknown state');
+    });
+
+    it('should stay in special state on CRLF inside </noscript> (GH-710)', () => {
+        let receivedEOF = false;
+
+        const tokenizer = new Tokenizer(tokenizerOpts, {
+            onEof(): void {
+                receivedEOF = true;
+            },
+            onComment: noop,
+            onDoctype: noop,
+            onStartTag: noop,
+            onEndTag: noop,
+            onCharacter: noop,
+            onNullCharacter: noop,
+            onWhitespaceCharacter: noop,
+        });
+
+        tokenizer.state = TokenizerMode.RAWTEXT;
+        tokenizer.lastStartTagName = 'noscript';
+
+        tokenizer.write('foo</noscript\r\n>', true);
+        expect(receivedEOF).toBeTruthy();
+        expect(tokenizer.state).toBe(TokenizerMode.DATA);
     });
 });

--- a/packages/parse5/lib/tokenizer/preprocessor.ts
+++ b/packages/parse5/lib/tokenizer/preprocessor.ts
@@ -159,7 +159,9 @@ export class Preprocessor {
             return $.EOF;
         }
 
-        return this.html.charCodeAt(pos);
+        const code = this.html.charCodeAt(pos);
+
+        return code === $.CARRIAGE_RETURN ? $.LINE_FEED : code;
     }
 
     public advance(): number {


### PR DESCRIPTION
Peeking didn't properly support carriage returns, which led the parser to hang in special tags.

Fixes #710