### PR TITLE
Bump version to v7.1.2

### DIFF
--- a/packages/parse5-parser-stream/package.json
+++ b/packages/parse5-parser-stream/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-parser-stream",
     "type": "module",
     "description": "Streaming HTML parser with scripting support.",
-    "version": "7.0.0",
+    "version": "7.1.2",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://github.com/inikulin/parse5",

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -2,7 +2,7 @@
     "name": "parse5",
     "type": "module",
     "description": "HTML parser and serializer.",
-    "version": "7.1.1",
+    "version": "7.1.2",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://github.com/inikulin/parse5",


### PR DESCRIPTION
This release includes `parse5` and `parse5-parser-stream`.

Changelog:

* Export `ERR` as `ErrorCodes` by @milahu in https://github.com/inikulin/parse5/pull/704
* Properly handle CR when peeking by @fb55 in https://github.com/inikulin/parse5/pull/715
* Add CJS build of `parser-stream` by @fb55 in https://github.com/inikulin/parse5/pull/716

**Full Changelog**: https://github.com/inikulin/parse5/compare/v7.1.0...v7.1.2