### PR TITLE
docs(readme): Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/inikulin/parse5/actions/workflows/nodejs-test.yml"><img alt="Build Status" src="https://img.shields.io/github/workflow/status/inikulin/parse5/Node.js%20CI?label=tests&style=flat"></a>
+  <a href="https://github.com/inikulin/parse5/actions/workflows/nodejs-test.yml"><img alt="Build Status" src="https://github.com/inikulin/parse5/actions/workflows/nodejs-test.yml/badge.svg"></a>
   <a href="https://www.npmjs.com/package/parse5"><img alt="NPM Version" src="https://img.shields.io/npm/v/parse5.svg"></a>
-  <a href="https://npmjs.org/package/parse5"><img alt="Downloads" src="http://img.shields.io/npm/dm/parse5.svg"></a>
-  <a href="https://npmjs.org/package/parse5"><img alt="Downloads total" src="http://img.shields.io/npm/dt/parse5.svg"></a>
+  <a href="https://npmjs.org/package/parse5"><img alt="Downloads" src="https://img.shields.io/npm/dm/parse5.svg"></a>
+  <a href="https://npmjs.org/package/parse5"><img alt="Downloads total" src="https://img.shields.io/npm/dt/parse5.svg"></a>
   <a href="https://coveralls.io/github/inikulin/parse5"><img alt="Coverage" src="https://img.shields.io/coveralls/github/inikulin/parse5/master"></a>
 </p>
 
@@ -31,7 +31,7 @@ as <a href="https://github.com/tmpvar/jsdom">jsdom</a>, <a href="https://angular
 </p>
 
 <p align="center">
-  <a href="http://astexplorer.net/#/1CHlCXc4n4">Online playground</a>
+  <a href="https://astexplorer.net/#/1CHlCXc4n4">Online playground</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Adresses badges/shields#8671

Also updates a few remaining `http://` links to use `https://`