### PR TITLE
Fixes exports used in the @parse5/tools types

### DIFF
--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -32,8 +32,13 @@
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
-        "import": "./dist/index.js",
-        "require": "./dist/cjs/index.js"
+        ".": {
+            "import": "./dist/index.js",
+            "require": "./dist/cjs/index.js"
+        },
+        "./dist/tree-adapters/default.js": {
+            "default": "./dist/tree-adapters/default.js"
+        }
     },
     "scripts": {
         "build:cjs": "tsc --module CommonJS --target ES6 --outDir dist/cjs && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json"


### PR DESCRIPTION
The `@parse5/tools` package references `parse5/dist/tree-adapters/default.js` in its imports (for example [here](https://github.com/parse5/parse5-tools/blob/main/src/attributes.ts#L1)), but since the path isn't part of the `exports` field it fails to resolve under certain TS configurations.