### PR TITLE
docs: fix variable name in sample code

### DIFF
--- a/packages/parse5/lib/serializer/index.ts
+++ b/packages/parse5/lib/serializer/index.ts
@@ -99,7 +99,7 @@ export function serialize<T extends TreeAdapterTypeMap = DefaultTreeAdapterMap>(
  * const document = parse5.parseFragment('<div>Hello, <b>world</b>!</div>');
  *
  * // Serializes the <div> element.
- * const html = parse5.serializeOuter(document.childNodes[0]);
+ * const str = parse5.serializeOuter(document.childNodes[0]);
  *
  * console.log(str); //> '<div>Hello, <b>world</b>!</div>'
  * ```


### PR DESCRIPTION
This code sample is using the wrong variable name. The declared variable is `html`, but on line 104 it tries to log a variable called `str`.

In line with [the similar example in the same file](https://github.com/inikulin/parse5/blob/badd96506b99a4101fc71853720d689ca573d592/packages/parse5/lib/serializer/index.ts#L69-L72), I renamed the variable to `str`.