### PR TITLE
chore(site): Fix typedoc config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "scripts": {
         "build": "npm run build:esm && npm run build:cjs --workspaces --if-present",
         "build:esm": "tsc --build packages/* test",
-        "build:docs": "node --max-old-space-size=8192 node_modules/.bin/typedoc .",
+        "build:docs": "typedoc",
         "prettier": "prettier '**/*.{js,ts,md,json,yml}' --loglevel warn",
         "format": "npm run format:es && npm run format:prettier",
         "format:es": "npm run lint:es -- --fix",

--- a/packages/parse5-html-rewriting-stream/typedoc.json
+++ b/packages/parse5-html-rewriting-stream/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../typedoc.base.json"],
+    "entryPoints": ["lib/index.ts"]
+}

--- a/packages/parse5-htmlparser2-tree-adapter/typedoc.json
+++ b/packages/parse5-htmlparser2-tree-adapter/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../typedoc.base.json"],
+    "entryPoints": ["lib/index.ts"]
+}

--- a/packages/parse5-parser-stream/typedoc.json
+++ b/packages/parse5-parser-stream/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../typedoc.base.json"],
+    "entryPoints": ["lib/index.ts"]
+}

--- a/packages/parse5-plain-text-conversion-stream/typedoc.json
+++ b/packages/parse5-plain-text-conversion-stream/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../typedoc.base.json"],
+    "entryPoints": ["lib/index.ts"]
+}

--- a/packages/parse5-sax-parser/lib/index.ts
+++ b/packages/parse5-sax-parser/lib/index.ts
@@ -41,6 +41,7 @@ export interface SAXParserOptions {
  */
 export class SAXParser extends Transform implements TokenHandler {
     protected options: SAXParserOptions;
+    /** @internal */
     protected parserFeedbackSimulator: ParserFeedbackSimulator;
     private pendingText: Text | null = null;
     private lastChunkWritten = false;

--- a/packages/parse5-sax-parser/typedoc.json
+++ b/packages/parse5-sax-parser/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../typedoc.base.json"],
+    "entryPoints": ["lib/index.ts"]
+}

--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -4,16 +4,15 @@ import type { DefaultTreeAdapterMap } from './tree-adapters/default.js';
 import type { TreeAdapterTypeMap } from './tree-adapters/interface.js';
 
 export { type DefaultTreeAdapterMap, defaultTreeAdapter } from './tree-adapters/default.js';
+export type * as DefaultTreeAdapterTypes from './tree-adapters/default.js';
 export type { TreeAdapter, TreeAdapterTypeMap } from './tree-adapters/interface.js';
 export { type ParserOptions, /** @internal */ Parser } from './parser/index.js';
 export { serialize, serializeOuter, type SerializerOptions } from './serializer/index.js';
-export { ERR as ErrorCodes, type ParserError } from './common/error-codes.js';
+export { ERR as ErrorCodes, type ParserError, type ParserErrorHandler } from './common/error-codes.js';
 
 /** @internal */
 export * as foreignContent from './common/foreign-content.js';
-/** @internal */
 export * as html from './common/html.js';
-/** @internal */
 export * as Token from './common/token.js';
 /** @internal */
 export { Tokenizer, type TokenizerOptions, TokenizerMode, type TokenHandler } from './tokenizer/index.js';

--- a/packages/parse5/lib/tree-adapters/interface.ts
+++ b/packages/parse5/lib/tree-adapters/interface.ts
@@ -30,7 +30,7 @@ export interface TreeAdapterTypeMap<
  * Note that `TreeAdapter` is not designed to be a general purpose AST manipulation library. You can build such library
  * on top of existing `TreeAdapter` or use one of the existing libraries from npm.
  *
- * @see The default implementation {@link parse5.treeAdapters.default}
+ * @see Have a look at the default tree adapter for reference.
  */
 export interface TreeAdapter<T extends TreeAdapterTypeMap = TreeAdapterTypeMap> {
     /**

--- a/packages/parse5/typedoc.json
+++ b/packages/parse5/typedoc.json
@@ -1,0 +1,4 @@
+{
+    "extends": ["../../typedoc.base.json"],
+    "entryPoints": ["lib/index.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     },
     "references": [{ "path": "packages/parse5/tsconfig.json" }],
     "typedocOptions": {
+        "entryPoints": ["packages/*"],
         "out": "docs/build",
         "name": "parse5",
         "readme": "README.md",

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://typedoc.org/schema.json",
+    "excludeInternal": true,
+    "excludePrivate": true,
+    "includeVersion": true
+}


### PR DESCRIPTION
typedoc has recently changed the way it builds monorepos, which led to website deploys failing. The changes remove the need to increase Node's heap size, but add several config files that have to be added.

I've also tried to remove a lot of the warnings that typedoc produces, by added `@internal` and `@private` comments where appropriate.

Fixes #874, by adding an export for all of the relevant types.