### PR TITLE
refactor: expose createTextNode on defaultTreeAdapter

### DIFF
--- a/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
+++ b/packages/parse5-htmlparser2-tree-adapter/lib/index.ts
@@ -27,10 +27,6 @@ export type Htmlparser2TreeAdapterMap = TreeAdapterTypeMap<
     ProcessingInstruction
 >;
 
-function createTextNode(value: string): Text {
-    return new Text(value);
-}
-
 function enquoteDoctypeId(id: string): string {
     const quote = id.includes('"') ? "'" : '"';
 
@@ -97,6 +93,10 @@ export const adapter: TreeAdapter<Htmlparser2TreeAdapterMap> = {
 
     createCommentNode(data: string): Comment {
         return new Comment(data);
+    },
+
+    createTextNode(value: string): Text {
+        return new Text(value);
     },
 
     //Tree mutation
@@ -189,7 +189,7 @@ export const adapter: TreeAdapter<Htmlparser2TreeAdapterMap> = {
         if (lastChild && isText(lastChild)) {
             lastChild.data += text;
         } else {
-            adapter.appendChild(parentNode, createTextNode(text));
+            adapter.appendChild(parentNode, adapter.createTextNode(text));
         }
     },
 
@@ -199,7 +199,7 @@ export const adapter: TreeAdapter<Htmlparser2TreeAdapterMap> = {
         if (prevNode && isText(prevNode)) {
             prevNode.data += text;
         } else {
-            adapter.insertBefore(parentNode, createTextNode(text), referenceNode);
+            adapter.insertBefore(parentNode, adapter.createTextNode(text), referenceNode);
         }
     },
 

--- a/packages/parse5/lib/tree-adapters/default.ts
+++ b/packages/parse5/lib/tree-adapters/default.ts
@@ -102,14 +102,6 @@ export type DefaultTreeAdapterMap = TreeAdapterTypeMap<
     DocumentType
 >;
 
-function createTextNode(value: string): TextNode {
-    return {
-        nodeName: '#text',
-        value,
-        parentNode: null,
-    };
-}
-
 export const defaultTreeAdapter: TreeAdapter<DefaultTreeAdapterMap> = {
     //Node construction
     createDocument(): Document {
@@ -142,6 +134,14 @@ export const defaultTreeAdapter: TreeAdapter<DefaultTreeAdapterMap> = {
         return {
             nodeName: '#comment',
             data,
+            parentNode: null,
+        };
+    },
+
+    createTextNode(value: string): TextNode {
+        return {
+            nodeName: '#text',
+            value,
             parentNode: null,
         };
     },
@@ -213,7 +213,7 @@ export const defaultTreeAdapter: TreeAdapter<DefaultTreeAdapterMap> = {
             }
         }
 
-        defaultTreeAdapter.appendChild(parentNode, createTextNode(text));
+        defaultTreeAdapter.appendChild(parentNode, defaultTreeAdapter.createTextNode(text));
     },
 
     insertTextBefore(parentNode: ParentNode, text: string, referenceNode: ChildNode): void {
@@ -222,7 +222,7 @@ export const defaultTreeAdapter: TreeAdapter<DefaultTreeAdapterMap> = {
         if (prevNode && defaultTreeAdapter.isTextNode(prevNode)) {
             prevNode.value += text;
         } else {
-            defaultTreeAdapter.insertBefore(parentNode, createTextNode(text), referenceNode);
+            defaultTreeAdapter.insertBefore(parentNode, defaultTreeAdapter.createTextNode(text), referenceNode);
         }
     },
 

--- a/packages/parse5/lib/tree-adapters/interface.ts
+++ b/packages/parse5/lib/tree-adapters/interface.ts
@@ -57,6 +57,13 @@ export interface TreeAdapter<T extends TreeAdapterTypeMap = TreeAdapterTypeMap> 
     createCommentNode(data: string): T['commentNode'];
 
     /**
+     * Creates a text node.
+     *
+     * @param value - Text.
+     */
+    createTextNode(value: string): T['textNode'];
+
+    /**
      * Creates a document node.
      */
     createDocument(): T['document'];


### PR DESCRIPTION
This PR exposes the `createTextNode()` method on the default tree adapter (#1031).

I pulled down the tests from [`html5lib-tests`](https://github.com/html5lib/html5lib-tests/tree/master) and ran them locally but wasn't sure there's any additional unit testing that should be included as part of this change.

I'm planning to open a follow-up PR on [parse5-tools](https://github.com/parse5/parse5-tools) to replace the existing `createTextNode` with the one provided here as described in #1031.