### PR TITLE
chore(ci): Update tested NodeJS versions

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -6,13 +6,13 @@ on:
             - 'dependabot/**'
     pull_request:
 
-permissions:
-    contents: read
-
 env:
     CI: true
     FORCE_COLOR: 2
-    NODE_COV: 16 # The Node.js version to run coveralls on
+    NODE_COV: lts/* # The Node.js version to run coveralls on
+
+permissions:
+    contents: read #  to fetch code (actions/checkout)
 
 jobs:
     lint:
@@ -21,7 +21,8 @@ jobs:
             - uses: actions/checkout@v4.1.1
               with:
                   submodules: recursive
-            - uses: actions/setup-node@v3.8.1
+            - name: Use Node.js ${{ matrix.node }}
+              uses: actions/setup-node@v3.8.1
               with:
                   node-version: lts/*
                   cache: npm
@@ -29,19 +30,19 @@ jobs:
             - run: npm run lint
 
     test:
+        permissions:
+            contents: read #  to fetch code (actions/checkout)
+            checks: write #  to create new checks (coverallsapp/github-action)
+
         name: Node ${{ matrix.node }}
         runs-on: ubuntu-latest
-        permissions:
-            checks: write # for coverallsapp/github-action to create new checks
-            contents: read # for actions/checkout to fetch code
 
         strategy:
             fail-fast: false
             matrix:
                 node:
-                    - '14'
-                    - '16'
-                    - '18'
+                    - 18
+                    - 20
                     - lts/*
 
         steps:
@@ -53,12 +54,10 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
                   cache: npm
-            - run: npm install -g npm@8.19.1
-              if: matrix.node == '14'
             - run: npm ci
             - run: npm run build --if-present
 
-            - name: Run Tests
+            - name: Run Jest
               run: npm run unit-tests
               if: matrix.node != env.NODE_COV
 


### PR DESCRIPTION
Several dependency updates are stalled as they no longer support old Node versions, so let's drop them from CI.