### PR TITLE
refactor(open-element-stack): Use sets everywhere

### DIFF
--- a/packages/parse5/lib/common/html.ts
+++ b/packages/parse5/lib/common/html.ts
@@ -554,9 +554,7 @@ export const SPECIAL_ELEMENTS: Record<NS, Set<TAG_ID>> = {
     [NS.XMLNS]: new Set(),
 };
 
-export function isNumberedHeader(tn: TAG_ID): boolean {
-    return tn === $.H1 || tn === $.H2 || tn === $.H3 || tn === $.H4 || tn === $.H5 || tn === $.H6;
-}
+export const NUMBERED_HEADERS = new Set([$.H1, $.H2, $.H3, $.H4, $.H5, $.H6]);
 
 const UNESCAPED_TEXT = new Set<string>([
     TAG_NAMES.STYLE,

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -13,7 +13,7 @@ import {
     ATTRS,
     SPECIAL_ELEMENTS,
     DOCUMENT_MODE,
-    isNumberedHeader,
+    NUMBERED_HEADERS,
     getTagID,
 } from '../common/html.js';
 import type { TreeAdapter, TreeAdapterTypeMap } from '../tree-adapters/interface.js';
@@ -1986,7 +1986,7 @@ function numberedHeaderStartTagInBody<T extends TreeAdapterTypeMap>(p: Parser<T>
         p._closePElement();
     }
 
-    if (isNumberedHeader(p.openElements.currentTagId)) {
+    if (NUMBERED_HEADERS.has(p.openElements.currentTagId)) {
         p.openElements.pop();
     }
 


### PR DESCRIPTION
Replaces the array searches and map lookups with sets and switch statements.

Also replaces the `isNumberedHeader` helper function with a set.