### PR TITLE
chore: upgrade to typescript 5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,6 +1643,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
             "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.7.0",
                 "@typescript-eslint/types": "8.7.0",
@@ -1671,6 +1672,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
             "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/types": "8.7.0",
                 "@typescript-eslint/visitor-keys": "8.7.0"
@@ -1688,6 +1690,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
             "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/typescript-estree": "8.7.0",
                 "@typescript-eslint/utils": "8.7.0",
@@ -2805,15 +2808,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/@eslint/js": {
-            "version": "9.10.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
-            "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
-            "dev": true,
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
         "node_modules/eslint/node_modules/eslint-visitor-keys": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
@@ -3264,7 +3258,8 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -6166,10 +6161,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8516,12 +8512,6 @@
                 "text-table": "^0.2.0"
             },
             "dependencies": {
-                "@eslint/js": {
-                    "version": "9.10.0",
-                    "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.10.0.tgz",
-                    "integrity": "sha512-fuXtbiP5GWIn8Fz+LWoOMVf/Jxm+aajZYkhi6CuEm4SxymFM+eUWzbO9qXT+L0iCkL5+KGYMCSGxo686H19S1g==",
-                    "dev": true
-                },
                 "eslint-visitor-keys": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
@@ -10976,9 +10966,9 @@
             }
         },
         "typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
             "dev": true
         },
         "typescript-eslint": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
         "noPropertyAccessFromIndexSignature": true,
         "forceConsistentCasingInFileNames": true,
         "isolatedModules": true,
-        "composite": true
+        "composite": true,
+        "skipLibCheck": true
     },
     "references": [{ "path": "packages/parse5/tsconfig.json" }],
     "typedocOptions": {


### PR DESCRIPTION
we needed `skipLibCheck` because `@types/node` has errors under latest typescript for whatever reason

that's why dependabot couldn't figure it out