### PR TITLE
fix: use typedoc config to avoid accidental inheritance

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,14 +15,5 @@
         "composite": true,
         "skipLibCheck": true
     },
-    "references": [{ "path": "packages/parse5/tsconfig.json" }],
-    "typedocOptions": {
-        "entryPoints": ["packages/*"],
-        "out": "docs/build",
-        "name": "parse5",
-        "readme": "README.md",
-        "emit": "docs",
-        "excludeInternal": true,
-        "entryPointStrategy": "packages"
-    }
+    "references": [{ "path": "packages/parse5/tsconfig.json" }]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,9 @@
+{
+    "entryPoints": ["packages/*"],
+    "out": "docs/build",
+    "name": "parse5",
+    "readme": "README.md",
+    "emit": "docs",
+    "excludeInternal": true,
+    "entryPointStrategy": "packages"
+}


### PR DESCRIPTION
Each of our `tsconfig.json` inherits the root `tsconfig.json`. This root config currently contains the typedoc configuration too, including `endPointStrategy: "packages"`.

This leads to each package in the repo having its own root-level typedoc config, which is causing typedoc to fail right now.

By moving the config to a `typedoc.json` at the root, we can continue inheriting `tsconfig.json` without accidentally inheriting the typedoc config.