### PR TITLE
chore: bump version to 7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6469,7 +6469,7 @@
             }
         },
         "packages/parse5": {
-            "version": "7.1.2",
+            "version": "7.2.0",
             "license": "MIT",
             "dependencies": {
                 "entities": "^4.5.0"
@@ -6491,7 +6491,7 @@
             }
         },
         "packages/parse5-htmlparser2-tree-adapter": {
-            "version": "7.0.0",
+            "version": "7.1.0",
             "license": "MIT",
             "dependencies": {
                 "domhandler": "^5.0.3",

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-htmlparser2-tree-adapter",
     "type": "module",
     "description": "htmlparser2 tree adapter for parse5.",
-    "version": "7.0.0",
+    "version": "7.1.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -2,7 +2,7 @@
     "name": "parse5",
     "type": "module",
     "description": "HTML parser and serializer.",
-    "version": "7.1.2",
+    "version": "7.2.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",


### PR DESCRIPTION
Release includes parse5 and parse5-htmlparser2-tree-adapter.

cc @fb55 I'm then going to merge this, tag main as 7.2.0 and npm publish the two individual packages 👀 