### PR TITLE
fix: export tree adapter types as namespace to support TS4.x

### DIFF
--- a/packages/parse5/lib/index.ts
+++ b/packages/parse5/lib/index.ts
@@ -4,7 +4,21 @@ import type { DefaultTreeAdapterMap } from './tree-adapters/default.js';
 import type { TreeAdapterTypeMap } from './tree-adapters/interface.js';
 
 export { type DefaultTreeAdapterMap, defaultTreeAdapter } from './tree-adapters/default.js';
-export type * as DefaultTreeAdapterTypes from './tree-adapters/default.js';
+import type * as DefaultTreeAdapter from './tree-adapters/default.js';
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace DefaultTreeAdapterTypes {
+    export type Document = DefaultTreeAdapter.Document;
+    export type DocumentFragment = DefaultTreeAdapter.DocumentFragment;
+    export type Element = DefaultTreeAdapter.Element;
+    export type CommentNode = DefaultTreeAdapter.CommentNode;
+    export type TextNode = DefaultTreeAdapter.TextNode;
+    export type Template = DefaultTreeAdapter.Template;
+    export type DocumentType = DefaultTreeAdapter.DocumentType;
+    export type ParentNode = DefaultTreeAdapter.ParentNode;
+    export type ChildNode = DefaultTreeAdapter.ChildNode;
+    export type Node = DefaultTreeAdapter.Node;
+    export type DefaultTreeAdapterMap = DefaultTreeAdapter.DefaultTreeAdapterMap;
+}
 export type { TreeAdapter, TreeAdapterTypeMap } from './tree-adapters/interface.js';
 export { type ParserOptions, /** @internal */ Parser } from './parser/index.js';
 export { serialize, serializeOuter, type SerializerOptions } from './serializer/index.js';

--- a/packages/parse5/lib/parser/open-element-stack.test.ts
+++ b/packages/parse5/lib/parser/open-element-stack.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'node:assert';
 import { TAG_ID as $, TAG_NAMES as TN, NS } from '../common/html.js';
 import { OpenElementStack } from './open-element-stack.js';
-import type { TreeAdapterTypeMap } from '../tree-adapters/interface';
+import type { TreeAdapterTypeMap } from '../tree-adapters/interface.js';
 import { generateTestsForEachTreeAdapter } from 'parse5-test-utils/utils/common.js';
 
 function ignore(): void {


### PR DESCRIPTION
Exports the tree adapter types as a namespace, individually. This reintroduces typescript 4.x support, which we accidentally broke in a non-breaking release.

Fixes #1299 

Before we merge this I need to double check it really does fix the problem. I tried building it with 4.x and it works but I need to check the types are still the same