### PR TITLE
Relax `<select>` parser (WHATWG proposal)

### DIFF
--- a/packages/parse5/lib/parser/open-element-stack.test.ts
+++ b/packages/parse5/lib/parser/open-element-stack.test.ts
@@ -409,23 +409,6 @@ generateTestsForEachTreeAdapter('open-element-stack', (treeAdapter) => {
         assert.ok(stack.hasTableBodyContextInTableScope());
     });
 
-    test('Has element in select scope', () => {
-        const stack = new OpenElementStack(treeAdapter.createDocument(), treeAdapter, stackHandler);
-
-        assert.ok(stack.hasInSelectScope($.P));
-
-        stack.push(createElement(TN.HTML), $.HTML);
-        stack.push(createElement(TN.DIV), $.DIV);
-        assert.ok(!stack.hasInSelectScope($.P));
-
-        stack.push(createElement(TN.P), $.P);
-        stack.push(createElement(TN.OPTION), $.OPTION);
-        assert.ok(stack.hasInSelectScope($.P));
-
-        stack.push(createElement(TN.DIV), $.DIV);
-        assert.ok(!stack.hasInSelectScope($.P));
-    });
-
     test('Generate implied end tags', () => {
         const stack = new OpenElementStack(treeAdapter.createDocument(), treeAdapter, stackHandler);
 

--- a/packages/parse5/lib/parser/open-element-stack.ts
+++ b/packages/parse5/lib/parser/open-element-stack.ts
@@ -18,12 +18,14 @@ const SCOPING_ELEMENTS_HTML = new Set([
     $.APPLET,
     $.CAPTION,
     $.HTML,
-    $.MARQUEE,
-    $.OBJECT,
     $.TABLE,
     $.TD,
-    $.TEMPLATE,
     $.TH,
+    $.OBJECT,
+    $.SELECT,
+    $.TEMPLATE,
+    // TODO: this does not seem to belong here? it's not in the spec
+    $.MARQUEE,
 ]);
 const SCOPING_ELEMENTS_HTML_LIST = new Set([...SCOPING_ELEMENTS_HTML, $.OL, $.UL]);
 const SCOPING_ELEMENTS_HTML_BUTTON = new Set([...SCOPING_ELEMENTS_HTML, $.BUTTON]);
@@ -336,29 +338,6 @@ export class OpenElementStack<T extends TreeAdapterTypeMap> {
                 }
                 case $.TABLE:
                 case $.HTML: {
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    hasInSelectScope(tagName: $): boolean {
-        for (let i = this.stackTop; i >= 0; i--) {
-            if (this.treeAdapter.getNamespaceURI(this.items[i]) !== NS.HTML) {
-                continue;
-            }
-
-            switch (this.tagIDs[i]) {
-                case tagName: {
-                    return true;
-                }
-                case $.OPTION:
-                case $.OPTGROUP: {
-                    break;
-                }
-                default: {
                     return false;
                 }
             }


### PR DESCRIPTION
https://github.com/html5lib/html5lib-tests/pull/178

The proposal isn't merged yet, and the error codes are off. The forked
html5lib-tests makes it more complicated. I recommend to ditch the fork
of html5lib-tests and give up on standardizing errors.
