### PR TITLE
chore: enable no-explicit-any rule as error level

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,7 +60,6 @@ export default [
         rules: {
             '@typescript-eslint/no-unsafe-declaration-merging': 'off',
             '@typescript-eslint/no-non-null-assertion': 'warn',
-            '@typescript-eslint/no-explicit-any': 'warn',
             '@typescript-eslint/explicit-function-return-type': 'error',
             '@typescript-eslint/consistent-type-imports': 'error',
 

--- a/packages/parse5-html-rewriting-stream/lib/index.ts
+++ b/packages/parse5-html-rewriting-stream/lib/index.ts
@@ -173,5 +173,6 @@ export interface RewritingStream {
      * @param event Name of the event
      * @param handler Event handler
      */
-    on(event: string, handler: (...args: never[]) => void): this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on(event: string, handler: (...args: any[]) => void): this;
 }

--- a/packages/parse5-html-rewriting-stream/lib/index.ts
+++ b/packages/parse5-html-rewriting-stream/lib/index.ts
@@ -173,5 +173,5 @@ export interface RewritingStream {
      * @param event Name of the event
      * @param handler Event handler
      */
-    on(event: string, handler: (...args: any[]) => void): this;
+    on(event: string, handler: (...args: never[]) => void): this;
 }

--- a/packages/parse5-parser-stream/lib/index.ts
+++ b/packages/parse5-parser-stream/lib/index.ts
@@ -144,5 +144,6 @@ export interface ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterM
      * @param event Name of the event
      * @param handler Event handler
      */
-    on(event: string, handler: (...args: never[]) => void): this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on(event: string, handler: (...args: any[]) => void): this;
 }

--- a/packages/parse5-parser-stream/lib/index.ts
+++ b/packages/parse5-parser-stream/lib/index.ts
@@ -144,5 +144,5 @@ export interface ParserStream<T extends TreeAdapterTypeMap = DefaultTreeAdapterM
      * @param event Name of the event
      * @param handler Event handler
      */
-    on(event: string, handler: (...args: any[]) => void): this;
+    on(event: string, handler: (...args: never[]) => void): this;
 }

--- a/packages/parse5-sax-parser/lib/index.ts
+++ b/packages/parse5-sax-parser/lib/index.ts
@@ -291,5 +291,5 @@ export interface SAXParser {
      * @param event Name of the event
      * @param handler Event handler
      */
-    on(event: string, handler: (...args: any[]) => void): this;
+    on(event: string, handler: (...args: never[]) => void): this;
 }

--- a/packages/parse5-sax-parser/lib/index.ts
+++ b/packages/parse5-sax-parser/lib/index.ts
@@ -291,5 +291,6 @@ export interface SAXParser {
      * @param event Name of the event
      * @param handler Event handler
      */
-    on(event: string, handler: (...args: never[]) => void): this;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    on(event: string, handler: (...args: any[]) => void): this;
 }

--- a/packages/parse5/lib/serializer/index.test.ts
+++ b/packages/parse5/lib/serializer/index.test.ts
@@ -58,7 +58,7 @@ describe('serializer', () => {
     });
 
     it('serializes unknown node to empty string', () => {
-        const unknown: any = {};
+        const unknown = {} as never;
         assert.strictEqual(serialize(unknown), '');
         assert.strictEqual(serializeOuter(unknown), '');
     });

--- a/packages/parse5/lib/tokenizer/index.test.ts
+++ b/packages/parse5/lib/tokenizer/index.test.ts
@@ -52,7 +52,7 @@ describe('Tokenizer methods', () => {
     });
 
     it('should throw if setting the state to an unknown value', () => {
-        const tokenizer = new Tokenizer(tokenizerOpts, {} as any);
+        const tokenizer = new Tokenizer(tokenizerOpts, {} as never);
         tokenizer.state = -1 as never;
         expect(() => tokenizer.write('foo', true)).toThrow('Unknown state');
     });


### PR DESCRIPTION
Removes our override such that `any` is no longer allowed, and replaces usages of it.

@fb55 this uncovered a curiosity:

the `Updating node source code location (GH-314)` test was basically asserting that you can have a custom source code location setter. i.e. you can have your own location shape

however, we have a strong type for `Location` and all tree adapters are required to return an `ElementLocation` from `getSourceCodeLocation` (which itself is a `Location`).

so while we do let you set whatever you want in `setSourceCodeLocation`, it doesn't make much sense to set anything that isn't a `Location`, as you need to get that back out in `getSourceCodeLocation` anyway.

tldr i think the test and the use case made sense way back, but has lost its meaning as we've strengthened types