### PR TITLE
doc: badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 <p align="center">
   <a href="https://github.com/inikulin/parse5/actions/workflows/nodejs-test.yml"><img alt="Build Status" src="https://github.com/inikulin/parse5/actions/workflows/nodejs-test.yml/badge.svg"></a>
   <a href="https://www.npmjs.com/package/parse5"><img alt="NPM Version" src="https://img.shields.io/npm/v/parse5.svg"></a>
-  <a href="https://npmjs.org/package/parse5"><img alt="Downloads" src="https://img.shields.io/npm/dm/parse5.svg"></a>
-  <a href="https://npmjs.org/package/parse5"><img alt="Downloads total" src="https://img.shields.io/npm/dt/parse5.svg"></a>
+  <a href="https://npm-compare.com/parse5/#timeRange=ALL"><img alt="Downloads" src="https://img.shields.io/npm/dm/parse5.svg"></a>
+  <a href="https://npm-compare.com/parse5/#timeRange=ALL"><img alt="Downloads total" src="https://img.shields.io/npm/dt/parse5.svg"></a>
   <a href="https://coveralls.io/github/inikulin/parse5"><img alt="Coverage" src="https://img.shields.io/coveralls/github/inikulin/parse5/master"></a>
 </p>
 


### PR DESCRIPTION
Hi, I’ve made an update to the README by replacing the NPM download badge with one that links to npm-compare.com, where users can view the dynamic download trends of [parse5](parse5). 

The second badge already links to the NPM page. The third and forth badge now links to npm-compare.com, where users can explore the download trends. This gives users a better perspective on the package’s growth and popularity, instead of simply repeating the link to the NPM package page.

As a maintainer of npm-compare.com, I’m happy to assist with any additional features or insights from our site if needed. Thanks for considering my suggestion!