### PR TITLE
feat: switch to ESM-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
         "vitest": "^3.0.1"
     },
     "scripts": {
-        "build": "npm run build:esm && npm run build:cjs --workspaces --if-present",
-        "build:esm": "tsc --build packages/* test",
+        "build": "tsc --build packages/* test",
         "build:docs": "typedoc",
         "prettier": "prettier '**/*.{js,ts,md,json,yml}' --log-level warn",
         "format": "npm run format:es && npm run format:prettier",

--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -20,7 +20,11 @@
     "main": "dist/index.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
-    "exports": "./dist/index.js",
+    "exports": {
+        ".": {
+            "default": "./dist/index.js"
+        }
+    },
     "dependencies": {
         "entities": "^6.0.0",
         "parse5": "^7.0.0",

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -14,26 +14,24 @@
         "htmlparser2"
     ],
     "license": "MIT",
-    "main": "dist/cjs/index.js",
+    "main": "dist/index.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
-        "import": "./dist/index.js",
-        "require": "./dist/cjs/index.js"
+        ".": {
+            "default": "./dist/index.js"
+        }
     },
     "dependencies": {
         "domhandler": "^5.0.3",
         "parse5": "^7.0.0"
     },
-    "scripts": {
-        "build:cjs": "tsc --noCheck --moduleResolution node10 --module CommonJS --target ES6 --outDir dist/cjs && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json"
-    },
+    "scripts": {},
     "repository": {
         "type": "git",
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist/cjs/package.json",
         "dist/**/*.js",
         "dist/**/*.d.ts"
     ]

--- a/packages/parse5-parser-stream/package.json
+++ b/packages/parse5-parser-stream/package.json
@@ -14,25 +14,23 @@
         "streaming"
     ],
     "license": "MIT",
-    "main": "dist/cjs/index.js",
+    "main": "dist/index.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
-        "import": "./dist/index.js",
-        "require": "./dist/cjs/index.js"
+        ".": {
+            "default": "./dist/index.js"
+        }
     },
     "dependencies": {
         "parse5": "^7.0.0"
     },
-    "scripts": {
-        "build:cjs": "tsc --noCheck --moduleResolution node10 --module CommonJS --target ES6 --outDir dist/cjs && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json"
-    },
+    "scripts": {},
     "repository": {
         "type": "git",
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist/cjs/package.json",
         "dist/**/*.js",
         "dist/**/*.d.ts"
     ]

--- a/packages/parse5-plain-text-conversion-stream/package.json
+++ b/packages/parse5-plain-text-conversion-stream/package.json
@@ -20,7 +20,11 @@
     "main": "dist/index.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
-    "exports": "./dist/index.js",
+    "exports": {
+        ".": {
+            "default": "./dist/index.js"
+        }
+    },
     "dependencies": {
         "parse5": "^7.0.0",
         "parse5-parser-stream": "^7.0.0"

--- a/packages/parse5-sax-parser/package.json
+++ b/packages/parse5-sax-parser/package.json
@@ -18,7 +18,11 @@
     "main": "dist/index.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
-    "exports": "./dist/index.js",
+    "exports": {
+        ".": {
+            "default": "./dist/index.js"
+        }
+    },
     "dependencies": {
         "parse5": "^7.0.0"
     },

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -28,22 +28,20 @@
         "serialize"
     ],
     "license": "MIT",
-    "main": "dist/cjs/index.js",
+    "main": "dist/index.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
-        "import": "./dist/index.js",
-        "require": "./dist/cjs/index.js"
+        ".": {
+            "default": "./dist/index.js"
+        }
     },
-    "scripts": {
-        "build:cjs": "tsc --noCheck --moduleResolution node10 --module CommonJS --target ES6 --outDir dist/cjs && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json"
-    },
+    "scripts": {},
     "repository": {
         "type": "git",
         "url": "git://github.com/inikulin/parse5.git"
     },
     "files": [
-        "dist/cjs/package.json",
         "dist/**/*.js",
         "dist/**/*.d.ts"
     ]


### PR DESCRIPTION
Switches the 3 remaining dual packages to ESM only:

- `parse5-htmlparser2-tree-adapter`
- `parse5-parser-stream`
- `parse5`

**NOTE:** we still haven't decided if we are ready to do this yet. just leaving this draft here for when we do one day