### PR TITLE
fix: handle exhaustive stack popping

### DIFF
--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -304,10 +304,11 @@ export class Parser<T extends TreeAdapterTypeMap> implements TokenHandler, Stack
     }
 
     protected _setContextModes(current: T['parentNode'], tid: number): void {
-        const isHTML = current === this.document || this.treeAdapter.getNamespaceURI(current) === NS.HTML;
+        const isHTML = current === this.document || (current && this.treeAdapter.getNamespaceURI(current) === NS.HTML);
 
         this.currentNotInHTML = !isHTML;
-        this.tokenizer.inForeignNode = !isHTML && !this._isIntegrationPoint(tid, current);
+        this.tokenizer.inForeignNode =
+            !isHTML && current !== undefined && tid !== undefined && !this._isIntegrationPoint(tid, current);
     }
 
     /** @protected */
@@ -419,7 +420,7 @@ export class Parser<T extends TreeAdapterTypeMap> implements TokenHandler, Stack
         } else {
             const parent = this.openElements.currentTmplContentOrNode;
 
-            this.treeAdapter.appendChild(parent, element);
+            this.treeAdapter.appendChild(parent ?? this.document, element);
         }
     }
 


### PR DESCRIPTION
In some weird cases it seems you can end up trying to pop the element
stack until you basically reach `-1` (i.e. `indexOf` failed to find what
we want).

If that happens, the current element will be `undefined`. This change
adds some handling around that.

@fb55 this is the one we talked about separately

finding it difficult to write a test for it since its a really strange state to get into