### PR TITLE
Fix broken links to documentation

### DIFF
--- a/packages/parse5-html-rewriting-stream/README.md
+++ b/packages/parse5-html-rewriting-stream/README.md
@@ -16,7 +16,7 @@
 <br>
 
 <p align="center">
-  📖 <a href="https://parse5.js.org/modules/parse5_html_rewriting_stream.html"><b>Documentation</b></a> 📖
+  📖 <a href="https://parse5.js.org/modules/parse5-html-rewriting-stream.html"><b>Documentation</b></a> 📖
 </p>
 
 ---

--- a/packages/parse5-htmlparser2-tree-adapter/README.md
+++ b/packages/parse5-htmlparser2-tree-adapter/README.md
@@ -16,7 +16,7 @@
 <br>
 
 <p align="center">
-  📖 <a href="https://parse5.js.org/modules/parse5_htmlparser2_tree_adapter.html"><b>Documentation</b></a> 📖
+  📖 <a href="https://parse5.js.org/modules/parse5-htmlparser2-tree-adapter.html"><b>Documentation</b></a> 📖
 </p>
 
 ---

--- a/packages/parse5-parser-stream/README.md
+++ b/packages/parse5-parser-stream/README.md
@@ -16,7 +16,7 @@
 <br>
 
 <p align="center">
-  📖 <a href="https://parse5.js.org/modules/parse5_parser_stream.html"><b>Documentation</b></a> 📖
+  📖 <a href="https://parse5.js.org/modules/parse5-parser-stream.html"><b>Documentation</b></a> 📖
 </p>
 
 ---

--- a/packages/parse5-plain-text-conversion-stream/README.md
+++ b/packages/parse5-plain-text-conversion-stream/README.md
@@ -16,7 +16,7 @@
 <br>
 
 <p align="center">
-  📖 <a href="https://parse5.js.org/modules/parse5_plain_text_conversion_stream.html"><b>Documentation</b></a> 📖
+  📖 <a href="https://parse5.js.org/modules/parse5-plain-text-conversion-stream.html"><b>Documentation</b></a> 📖
 </p>
 
 ---

--- a/packages/parse5-sax-parser/README.md
+++ b/packages/parse5-sax-parser/README.md
@@ -16,7 +16,7 @@
 <br>
 
 <p align="center">
-  📖 <a href="https://parse5.js.org/modules/parse5_sax_parser.html"><b>Documentation</b></a> 📖
+  📖 <a href="https://parse5.js.org/modules/parse5-sax-parser.html"><b>Documentation</b></a> 📖
 </p>
 
 ---


### PR DESCRIPTION
Used '_' where it should have been '-'