### PR TITLE
chore: bump to version 7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8410,7 +8410,7 @@
             }
         },
         "packages/parse5": {
-            "version": "7.2.1",
+            "version": "7.3.0",
             "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
@@ -8420,7 +8420,7 @@
             }
         },
         "packages/parse5-html-rewriting-stream": {
-            "version": "7.0.0",
+            "version": "7.1.0",
             "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0",

--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-html-rewriting-stream",
     "type": "module",
     "description": "Streaming HTML rewriter.",
-    "version": "7.0.0",
+    "version": "7.1.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -2,7 +2,7 @@
     "name": "parse5",
     "type": "module",
     "description": "HTML parser and serializer.",
-    "version": "7.2.1",
+    "version": "7.3.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",


### PR DESCRIPTION
Bumps parse5 to 7.3.0, and parse5-html-rewriting-stream to 7.1.0