### PR TITLE
feat: bump to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,28 +39,6 @@
                 "parse5": "npm:parse5"
             }
         },
-        "bench/node_modules/entities": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "bench/node_modules/parse5": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-            "dependencies": {
-                "entities": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
-        },
         "node_modules/@aashutoshrathi/word-wrap": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -4653,7 +4631,7 @@
             }
         },
         "packages/parse5": {
-            "version": "7.3.0",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
@@ -4663,21 +4641,21 @@
             }
         },
         "packages/parse5-html-rewriting-stream": {
-            "version": "7.1.0",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0",
-                "parse5": "^7.0.0",
-                "parse5-sax-parser": "^7.0.0"
+                "parse5": "^8.0.0",
+                "parse5-sax-parser": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-html-rewriting-stream/node_modules/entities": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-            "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -4687,51 +4665,63 @@
             }
         },
         "packages/parse5-htmlparser2-tree-adapter": {
-            "version": "7.1.0",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
                 "domhandler": "^5.0.3",
-                "parse5": "^7.0.0"
+                "parse5": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-parser-stream": {
-            "version": "7.1.2",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
-                "parse5": "^7.0.0"
+                "parse5": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5-plain-text-conversion-stream": {
-            "version": "7.0.0",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
-                "parse5": "^7.0.0",
-                "parse5-parser-stream": "^7.0.0"
+                "parse5": "^8.0.0",
+                "parse5-parser-stream": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
+        "packages/parse5-plain-text-conversion-stream/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "packages/parse5-sax-parser": {
-            "version": "7.0.0",
+            "version": "8.0.0",
             "license": "MIT",
             "dependencies": {
-                "parse5": "^7.0.0"
+                "parse5": "^8.0.0"
             },
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "packages/parse5/node_modules/entities": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-            "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -6961,9 +6951,9 @@
             },
             "dependencies": {
                 "entities": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-                    "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw=="
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+                    "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
                 }
             }
         },
@@ -6974,6 +6964,14 @@
                 "benchmark": "^2.1.4",
                 "human-format": "^1.2.1",
                 "parse5": "npm:parse5"
+            }
+        },
+        "parse5-html-rewriting-stream": {
+            "version": "file:packages/parse5-html-rewriting-stream",
+            "requires": {
+                "entities": "^6.0.0",
+                "parse5": "^8.0.0",
+                "parse5-sax-parser": "^8.0.0"
             },
             "dependencies": {
                 "entities": {
@@ -6988,21 +6986,13 @@
                     "requires": {
                         "entities": "^6.0.0"
                     }
-                }
-            }
-        },
-        "parse5-html-rewriting-stream": {
-            "version": "file:packages/parse5-html-rewriting-stream",
-            "requires": {
-                "entities": "^6.0.0",
-                "parse5": "^7.0.0",
-                "parse5-sax-parser": "^7.0.0"
-            },
-            "dependencies": {
-                "entities": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
-                    "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw=="
+                },
+                "parse5-sax-parser": {
+                    "version": "https://registry.npmjs.org/parse5-sax-parser/-/parse5-sax-parser-7.0.0.tgz",
+                    "integrity": "sha512-5A+v2SNsq8T6/mG3ahcz8ZtQ0OUFTatxPbeidoMB7tkJSGDY3tdfl4MHovtLQHkEn5CGxijNWRQHhRQ6IRpXKg==",
+                    "requires": {
+                        "parse5": "^7.0.0"
+                    }
                 }
             }
         },
@@ -7010,26 +7000,48 @@
             "version": "file:packages/parse5-htmlparser2-tree-adapter",
             "requires": {
                 "domhandler": "^5.0.3",
-                "parse5": "^7.0.0"
+                "parse5": "^8.0.0"
             }
         },
         "parse5-parser-stream": {
             "version": "file:packages/parse5-parser-stream",
             "requires": {
-                "parse5": "^7.0.0"
+                "parse5": "^8.0.0"
             }
         },
         "parse5-plain-text-conversion-stream": {
             "version": "file:packages/parse5-plain-text-conversion-stream",
             "requires": {
-                "parse5": "^7.0.0",
-                "parse5-parser-stream": "^7.0.0"
+                "parse5": "^8.0.0",
+                "parse5-parser-stream": "^8.0.0"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+                    "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
+                },
+                "parse5": {
+                    "version": "7.3.0",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+                    "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+                    "requires": {
+                        "entities": "^6.0.0"
+                    }
+                },
+                "parse5-parser-stream": {
+                    "version": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+                    "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+                    "requires": {
+                        "parse5": "^7.0.0"
+                    }
+                }
             }
         },
         "parse5-sax-parser": {
             "version": "file:packages/parse5-sax-parser",
             "requires": {
-                "parse5": "^7.0.0"
+                "parse5": "^8.0.0"
             }
         },
         "parse5-test-utils": {

--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-html-rewriting-stream",
     "type": "module",
     "description": "Streaming HTML rewriter.",
-    "version": "7.1.0",
+    "version": "8.0.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",
@@ -27,8 +27,8 @@
     },
     "dependencies": {
         "entities": "^6.0.0",
-        "parse5": "^7.0.0",
-        "parse5-sax-parser": "^7.0.0"
+        "parse5": "^8.0.0",
+        "parse5-sax-parser": "^8.0.0"
     },
     "repository": {
         "type": "git",

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-htmlparser2-tree-adapter",
     "type": "module",
     "description": "htmlparser2 tree adapter for parse5.",
-    "version": "7.1.0",
+    "version": "8.0.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "domhandler": "^5.0.3",
-        "parse5": "^7.0.0"
+        "parse5": "^8.0.0"
     },
     "scripts": {},
     "repository": {

--- a/packages/parse5-parser-stream/package.json
+++ b/packages/parse5-parser-stream/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-parser-stream",
     "type": "module",
     "description": "Streaming HTML parser with scripting support.",
-    "version": "7.1.2",
+    "version": "8.0.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",
@@ -23,7 +23,7 @@
         }
     },
     "dependencies": {
-        "parse5": "^7.0.0"
+        "parse5": "^8.0.0"
     },
     "scripts": {},
     "repository": {

--- a/packages/parse5-plain-text-conversion-stream/package.json
+++ b/packages/parse5-plain-text-conversion-stream/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-plain-text-conversion-stream",
     "type": "module",
     "description": "Stream that converts plain text files into HTML document.",
-    "version": "7.0.0",
+    "version": "8.0.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",
@@ -26,8 +26,8 @@
         }
     },
     "dependencies": {
-        "parse5": "^7.0.0",
-        "parse5-parser-stream": "^7.0.0"
+        "parse5": "^8.0.0",
+        "parse5-parser-stream": "^8.0.0"
     },
     "repository": {
         "type": "git",

--- a/packages/parse5-sax-parser/package.json
+++ b/packages/parse5-sax-parser/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-sax-parser",
     "type": "module",
     "description": "Streaming SAX-style HTML parser.",
-    "version": "7.0.0",
+    "version": "8.0.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",
@@ -24,7 +24,7 @@
         }
     },
     "dependencies": {
-        "parse5": "^7.0.0"
+        "parse5": "^8.0.0"
     },
     "repository": {
         "type": "git",

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -2,7 +2,7 @@
     "name": "parse5",
     "type": "module",
     "description": "HTML parser and serializer.",
-    "version": "7.3.0",
+    "version": "8.0.0",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": "https://github.com/inikulin/parse5/graphs/contributors",
     "homepage": "https://parse5.js.org",


### PR DESCRIPTION
Bumps all packages and their parse5 dependencies to 8.0.0.

This isn't strictly necessary as some packages will continue to work
with 7.x, but it may be easier for maintenance in future to draw the
line.
