### PR TITLE
chore: v8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,28 +38,6 @@
                 "parse5": "npm:parse5"
             }
         },
-        "bench/node_modules/entities": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "bench/node_modules/parse5": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-            "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-            "dependencies": {
-                "entities": "^6.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/inikulin/parse5?sponsor=1"
-            }
-        },
         "node_modules/@aashutoshrathi/word-wrap": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -3417,7 +3395,7 @@
             }
         },
         "packages/parse5": {
-            "version": "8.0.0",
+            "version": "8.0.1",
             "license": "MIT",
             "dependencies": {
                 "entities": "^8.0.0"
@@ -3427,7 +3405,7 @@
             }
         },
         "packages/parse5-html-rewriting-stream": {
-            "version": "8.0.0",
+            "version": "8.0.1",
             "license": "MIT",
             "dependencies": {
                 "entities": "^8.0.0",
@@ -3439,7 +3417,7 @@
             }
         },
         "packages/parse5-htmlparser2-tree-adapter": {
-            "version": "8.0.0",
+            "version": "8.0.1",
             "license": "MIT",
             "dependencies": {
                 "domhandler": "^6.0.1",
@@ -5158,21 +5136,6 @@
                 "benchmark": "^2.1.4",
                 "human-format": "^1.2.1",
                 "parse5": "npm:parse5"
-            },
-            "dependencies": {
-                "entities": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-                    "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
-                },
-                "parse5": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-                    "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-                    "requires": {
-                        "entities": "^6.0.0"
-                    }
-                }
             }
         },
         "parse5-html-rewriting-stream": {

--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-html-rewriting-stream",
     "type": "module",
     "description": "Streaming HTML rewriter.",
-    "version": "8.0.0",
+    "version": "8.0.1",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": [
         "James Garbutt (https://github.com/43081j)",

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -2,7 +2,7 @@
     "name": "parse5-htmlparser2-tree-adapter",
     "type": "module",
     "description": "htmlparser2 tree adapter for parse5.",
-    "version": "8.0.0",
+    "version": "8.0.1",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": [
         "James Garbutt (https://github.com/43081j)",

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -2,7 +2,7 @@
     "name": "parse5",
     "type": "module",
     "description": "HTML parser and serializer.",
-    "version": "8.0.0",
+    "version": "8.0.1",
     "author": "Ivan Nikulin <ifaaan@gmail.com> (https://github.com/inikulin)",
     "contributors": [
         "James Garbutt (https://github.com/43081j)",


### PR DESCRIPTION
Bumps `parse`, `parse5-html-rewriting-stream`, and
`parse5-htmlparser2-tree-adapter`.
