### PR TITLE
chore: use HTTPS repository URL

### DIFF
--- a/packages/parse5-html-rewriting-stream/package.json
+++ b/packages/parse5-html-rewriting-stream/package.json
@@ -37,7 +37,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/inikulin/parse5.git"
+        "url": "https://github.com/inikulin/parse5.git"
     },
     "files": [
         "dist/**/*.js",

--- a/packages/parse5-htmlparser2-tree-adapter/package.json
+++ b/packages/parse5-htmlparser2-tree-adapter/package.json
@@ -34,7 +34,7 @@
     "scripts": {},
     "repository": {
         "type": "git",
-        "url": "git://github.com/inikulin/parse5.git"
+        "url": "https://github.com/inikulin/parse5.git"
     },
     "files": [
         "dist/**/*.js",

--- a/packages/parse5-parser-stream/package.json
+++ b/packages/parse5-parser-stream/package.json
@@ -33,7 +33,7 @@
     "scripts": {},
     "repository": {
         "type": "git",
-        "url": "git://github.com/inikulin/parse5.git"
+        "url": "https://github.com/inikulin/parse5.git"
     },
     "files": [
         "dist/**/*.js",

--- a/packages/parse5-plain-text-conversion-stream/package.json
+++ b/packages/parse5-plain-text-conversion-stream/package.json
@@ -36,7 +36,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/inikulin/parse5.git"
+        "url": "https://github.com/inikulin/parse5.git"
     },
     "files": [
         "dist/**/*.js",

--- a/packages/parse5-sax-parser/package.json
+++ b/packages/parse5-sax-parser/package.json
@@ -33,7 +33,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git://github.com/inikulin/parse5.git"
+        "url": "https://github.com/inikulin/parse5.git"
     },
     "files": [
         "dist/**/*.js",

--- a/packages/parse5/package.json
+++ b/packages/parse5/package.json
@@ -44,7 +44,7 @@
     "scripts": {},
     "repository": {
         "type": "git",
-        "url": "git://github.com/inikulin/parse5.git"
+        "url": "https://github.com/inikulin/parse5.git"
     },
     "files": [
         "dist/**/*.js",


### PR DESCRIPTION
Updates the package repository metadata to use HTTPS instead of the unauthenticated `git://` protocol.

Validation:
- `git diff --check`
- parsed the changed `package.json` file(s) with Node.js