### PR TITLE
fix: do not let a foreign end tag close an HTML element

### DIFF
--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -90,6 +90,24 @@ describe('parser', () => {
         expect(onParseError).not.toHaveBeenCalled();
     });
 
+    it('Regression - foreign end tag must not close an HTML element with a colliding tag id', () => {
+        // `<svg desc>` is a foreign element whose lowercase name collides with the HTML
+        // `desc` tag id. The "any other end tag" rule in body requires an HTML element,
+        // so `</desc>` must be ignored and the open `<b>` must stay open and collect "y".
+        const document = parse('<svg><desc><b>x</desc>y');
+
+        const html = document.childNodes[0] as Element;
+        const body = html.childNodes[1] as Element;
+        const svg = body.childNodes[0] as Element;
+        const desc = svg.childNodes[0] as Element;
+        const b = desc.childNodes[0] as Element;
+
+        expect(b.nodeName).toBe('b');
+        expect(b.childNodes).toHaveLength(1);
+        expect(b.childNodes[0].nodeName).toBe('#text');
+        expect((b.childNodes[0] as TextNode).value).toBe('xy');
+    });
+
     describe('Tree adapters', () => {
         it('should support onItemPush and onItemPop', () => {
             const onItemPush = vi.fn();

--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -90,7 +90,8 @@ describe('parser', () => {
         expect(onParseError).not.toHaveBeenCalled();
     });
 
-    it('Regression - foreign end tag must not close an HTML element with a colliding tag id', () => {
+    // TODO: this belongs in html5lib-tests upstream; kept here for now.
+    it('end tag in body must not match a foreign element with the same tag ID', () => {
         // `<svg desc>` is a foreign element whose lowercase name collides with the HTML
         // `desc` tag id. The "any other end tag" rule in body requires an HTML element,
         // so `</desc>` must be ignored and the open `<b>` must stay open and collect "y".

--- a/packages/parse5/lib/parser/index.ts
+++ b/packages/parse5/lib/parser/index.ts
@@ -2608,7 +2608,14 @@ function genericEndTagInBody<T extends TreeAdapterTypeMap>(p: Parser<T>, token: 
         const elementId = p.openElements.tagIDs[i];
 
         // Compare the tag name here, as the tag might not be a known tag with an ID.
-        if (tid === elementId && (tid !== $.UNKNOWN || p.treeAdapter.getTagName(element) === tn)) {
+        // The matched element must be an HTML element (per the WHATWG "any other end tag"
+        // rule); a foreign element with a colliding tag ID must fall through to the
+        // special-element check below so the end tag is ignored.
+        if (
+            tid === elementId &&
+            p.treeAdapter.getNamespaceURI(element) === NS.HTML &&
+            (tid !== $.UNKNOWN || p.treeAdapter.getTagName(element) === tn)
+        ) {
             p.openElements.generateImpliedEndTagsWithExclusion(tid);
             if (p.openElements.stackTop >= i) p.openElements.shortenToLength(i);
             break;


### PR DESCRIPTION
The "any other end tag" rule for the in-body insertion mode (WHATWG 13.2.6.4.7, step 3) only matches an open node that is an HTML element; anything else falls through to step 4 (special element check, then ignore).

`genericEndTagInBody` matched an open element by tag id alone, without checking its namespace. A foreign integration-point element (`desc`, `title`, `mi`, `mo`, `mn`, `ms`, `mtext`, `annotation-xml`) whose lowercase name collides with an HTML tag id was therefore wrongly matched, closing an open HTML formatting element that should stay open.

## Repro

```
<svg><desc><b>x</desc>y
```

The foreign `<svg desc>` end tag `</desc>` must not close the open `<b>`, so `<b>` stays open and collects the trailing text. Browser-confirmed correct output:

```
| <html>
|   <head>
|   <body>
|     <svg svg>
|       <svg desc>
|         <b>
|           "xy"
```

Before this fix parse5 produced `b.text = "x"` (the `<b>` was wrongly closed and `"y"` leaked out as a sibling); the correct result is `b.text = "xy"`.

## Fix

Add `p.treeAdapter.getNamespaceURI(element) === NS.HTML` to the match condition (`NS` is already imported) so a foreign element falls through to the namespace-aware `_isSpecialElement` check and the end tag is ignored, as the spec requires.

## Tests

Added a focused regression test in `packages/parse5/lib/parser/index.test.ts` asserting `b.text === "xy"`. It fails on the pristine source (`expected "x" to be "xy"`) and passes with the fix. The full conformance suite stays green at 19,325 cases (unchanged).