### PR TITLE
fix: treat numeric character reference CR as whitespace

### DIFF
--- a/packages/parse5/lib/parser/index.test.ts
+++ b/packages/parse5/lib/parser/index.test.ts
@@ -1,5 +1,5 @@
 import { it, assert, describe, beforeEach, afterEach, vi, expect } from 'vitest';
-import { parseFragment, parse } from 'parse5';
+import { parseFragment, parse, serialize } from 'parse5';
 import type { Element, TextNode } from '../tree-adapters/default.js';
 import { generateParsingTests } from 'parse5-test-utils/utils/generate-parsing-tests.js';
 import { treeAdapters } from 'parse5-test-utils/utils/common.js';
@@ -88,6 +88,14 @@ describe('parser', () => {
         parse('<!doctype html><noscript>foo</noscript\r\n>', { onParseError });
 
         expect(onParseError).not.toHaveBeenCalled();
+    });
+
+    it('Regression - numeric character reference for CR treated as whitespace (GH-1828)', () => {
+        const space = serialize(parse('&#32;A'));
+
+        assert.strictEqual(serialize(parse('&#13;A')), space);
+        assert.strictEqual(serialize(parse('&#x0D;A')), space);
+        assert.ok(!serialize(parse('&#13;A')).includes('\r'));
     });
 
     describe('Tree adapters', () => {

--- a/packages/parse5/lib/tokenizer/index.ts
+++ b/packages/parse5/lib/tokenizer/index.ts
@@ -140,7 +140,9 @@ function toAsciiLower(cp: number): number {
 }
 
 function isWhitespace(cp: number): boolean {
-    return cp === $.SPACE || cp === $.LINE_FEED || cp === $.TABULATION || cp === $.FORM_FEED;
+    return (
+        cp === $.SPACE || cp === $.LINE_FEED || cp === $.TABULATION || cp === $.FORM_FEED || cp === $.CARRIAGE_RETURN
+    );
 }
 
 function isScriptDataDoubleEscapeSequenceEnd(cp: number): boolean {


### PR DESCRIPTION
A leading `&#13;` / `&#x0D;` was emitted as a CHARACTER token because `isWhitespace()` did not include U+000D. Literal CRs are rewritten to LF by the preprocessor, so this only showed up for numeric character references.

The before-html / before-head / in-head / after-head insertion modes then treated that token as “anything else” and inserted a stray CR text node in `<body>` instead of ignoring it.

This adds `CARRIAGE_RETURN` to `isWhitespace`. It does not rewrite NCR 0x0D to LF — the spec reports that as `controlCharacterReference` and keeps U+000D.

Reported and diagnosed by @maximilliangrand.

Fixes #1828